### PR TITLE
Introduce trace extraction capability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,17 +20,8 @@ FetchContent_MakeAvailable(argparse)
 
 include_directories(include)
 
-set(LIB_SRC_FILES
-    src/model_checker/smc_engine.cpp
-    src/model_checker/state_generation.cpp
-    src/model_checker/statistical_model_checker.cpp
-    src/parser/parsers.cpp
-    src/properties/property_description.cpp
-    src/samples/batch_statistics.cpp
-    src/samples/exploration_information.cpp
-    src/samples/model_sampling.cpp
-    src/samples/sampling_results.cpp
-)
+# Add all storm sources except cli.cpp
+file(GLOB_RECURSE LIB_SRC_FILES ${PROJECT_SOURCE_DIR}/src/*/*.cpp)
 
 add_library(${PROJECT_NAME}_lib ${LIB_SRC_FILES})
 target_include_directories(${PROJECT_NAME}_lib PUBLIC ${storm_INCLUDE_DIR} ${storm-parsers_INCLUDE_DIR})
@@ -55,4 +46,8 @@ if(BUILD_TESTING)
   add_executable(test_models test/test_models.cpp)
   target_link_libraries(test_models ${PROJECT_NAME}_lib GTest::gtest GTest::gtest_main)
   gtest_add_tests(TARGET test_models)
+
+  add_executable(test_trace_export test/test_trace_export.cpp)
+  target_link_libraries(test_trace_export ${PROJECT_NAME}_lib GTest::gtest GTest::gtest_main)
+  gtest_add_tests(TARGET test_trace_export)
 endif()

--- a/README.md
+++ b/README.md
@@ -22,16 +22,27 @@ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && make -j4
 # optionally, run the unit tests to make sure everything works as expected
 ./test_models
 ```
-
-## Run your first example
-Open your terminal in the cloned repository and execute the following
+## Run the executable
+To make the smc_storm executable usable from any folder, we suggest to add the following line to your `~/.bashrc` file or run it before start using the tool:
 ```bash
 # Make smc_storm executable from anywhere
 export PATH=$PATH:<path-to-smc-storm-repo>/build
+```
+
+## Available parameters
+The list of available parameters with its related description can be obtained using following command:
+```bash
+smc_storm --help
+```
+
+## Examples
+```bash
 # Example 1
-smc_storm --model <path-to-smc-storm-repo>/test/test_files/leader_sync.3-2.v1.jani --property-name eventually_elected
+smc_storm --model <path-to-smc-storm-repo>/test/test_files/leader_sync.3-2.v1.jani --property-name eventually_elected --batch-size 200
 # Example 2
 smc_storm --model <path-to-smc-storm-repo>/test/test_files/nand.v1.jani --property-name reliable --constants "N=20,K=2" --epsilon 0.01 --confidence 0.95 --n-threads 5 --show-statistics
+# Example 3 (rm added to make sure the csv file doesn't exist at smc_storm execution time)
+rm -f exported_traces.csv && smc_storm --model <path-to-smc-storm-repo>/test/test_files/leader_sync.3-2.v1.jani --property-name time --traces-file exported_traces.csv --show-statistics --max-n-traces 5
 ```
 
 ### Verifying sin and cos support

--- a/include/model_checker/smc_engine.h
+++ b/include/model_checker/smc_engine.h
@@ -32,6 +32,7 @@
 #include "samples/sampling_results.h"
 #include "samples/model_sampling.h"
 #include "samples/trace_information.hpp"
+#include "samples/traces_exporter.h"
 
 // Fwd declaration for storm::Environment
 namespace storm {
@@ -74,6 +75,10 @@ class StatisticalExplorationModelChecker : public storm::modelchecker::AbstractM
    private:
     bool verifyModelValid() const;
 
+    bool verifySettingsValid() const;
+
+    bool traceStorageEnabled() const;
+
     std::vector<uint_fast32_t> getThreadSeeds() const;
 
     /*!
@@ -82,19 +87,9 @@ class StatisticalExplorationModelChecker : public storm::modelchecker::AbstractM
      * @param model_sampler Object used to randomly sample next action and states
      * @param sampling_results Object keeping track of the previous sample results and defining if new samples are needed
      */
-    void performProbabilitySampling(
+    void performSampling(
         storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& check_task,
-        samples::ModelSampling<StateType, ValueType> const& model_sampler, samples::SamplingResults& sampling_results) const;
-    
-    /*!
-     * @brief Generates samples from a model and evaluates rewards on them as long as it is needed
-     * @param check_task The property and rewards we are evaluating on the loaded model
-     * @param model_sampler Object used to randomly sample next action and states
-     * @param sampling_results Object keeping track of the previous sample results and defining if new samples are needed
-     */
-    void performRewardSampling(
-        storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& check_task,
-        samples::ModelSampling<StateType, ValueType> const& model_sampler, samples::SamplingResults& sampling_results) const;
+        samples::ModelSampling<StateType, ValueType> const& model_sampler, samples::SamplingResults& sampling_results);
 
     /*!
      * @brief Sample a single path until we reach a state it doesn't make sense to expand further
@@ -122,6 +117,7 @@ class StatisticalExplorationModelChecker : public storm::modelchecker::AbstractM
     // The model to check.
     const storm::storage::SymbolicModelDescription _model;
     const settings::SmcSettings _settings;
+    std::unique_ptr<samples::TracesExporter> _traces_exporter_ptr;
 };
 }  // namespace model_checker
 }  // namespace smc_storm

--- a/include/model_checker/state_generation.h
+++ b/include/model_checker/state_generation.h
@@ -38,25 +38,19 @@ template<typename StateType, typename ValueType>
 class StateGeneration {
    public:
     /*!
-     * @brief Base constructor for StateGeneration class
-     * @param model The model to generate the next states from
-     * @param formula The formula to evaluate on the generated states
-     * @param exploration_information Structure that keeps track of the already explored states
-     * @param build_rewards Whether to embed the rewards in the model we are building up
-     */
-    StateGeneration(storm::storage::SymbolicModelDescription const& model, storm::logic::Formula const& formula,
-                    samples::ExplorationInformation<StateType, ValueType>& exploration_information,
-                    bool const build_rewards = false);
-
-    /*!
      * @brief Extension of the constructor above, in case we evaluate Rewards
      * @param model The model to generate the next states from
      * @param formula The formula to evaluate on the generated states
-     * @param reward_model Name of the reward model to use for assigning costs on states and actions
+     * @param reward_model Name of the reward model to use for assigning costs on states and actions. Empty for P properties
      * @param exploration_information Structure that keeps track of the already explored states
      */
     StateGeneration(storm::storage::SymbolicModelDescription const& model, storm::logic::Formula const& formula,
                     std::string const& reward_model, samples::ExplorationInformation<StateType, ValueType>& exploration_information);
+
+    inline const storm::generator::VariableInformation& getVariableInformation() const
+    {
+        return _generator_ptr->getVariableInformation();
+    }
 
     /*!
      * @brief Check if a reward model is loaded and therefore it needs to be evaluated

--- a/include/samples/exploration_information.h
+++ b/include/samples/exploration_information.h
@@ -42,7 +42,18 @@ class ExplorationInformation {
     typedef typename IdToStateMap::const_iterator const_iterator;
     typedef std::vector<std::vector<storm::storage::MatrixEntry<StateType, ValueType>>> MatrixType;
 
-    ExplorationInformation();
+    /*!
+     * @brief Constructor for the ExplorationInformation class
+     * @param store_expanded_states If true, the class will store all expanded raw states in memory
+     */
+    ExplorationInformation(const bool store_expanded_states);
+
+    /*!
+     * @brief Return the compressed state associated to the input state id
+     * @param state the ID of the requested compressed state
+     * @return A compressed state
+     */
+    storm::generator::CompressedState const& getCompressedState(StateType const& state) const;
 
     const_iterator findUnexploredState(StateType const& state) const;
 
@@ -120,14 +131,16 @@ class ExplorationInformation {
 
     std::vector<storm::storage::MatrixEntry<StateType, ValueType>> const& getRowOfMatrix(ActionType const& row) const;
 
-    ValueType const& getActionReward(ActionType const& actionId) const;
+    ValueType const& getActionReward(ActionType const& action_id) const;
 
     void addActionsToMatrix(size_t const& count);
 
-    void addActionReward(ActionType const& actionId, ValueType const& actionReward);
+    void addActionReward(ActionType const& action_id, ValueType const& action_reward);
 
    private:
     static constexpr ActionType _unexplored_marker{std::numeric_limits<ActionType>::max()};
+    // Flag to signal whether to store the compressed states or not
+    const bool _store_expanded_states;
     // Assigns to each actionId (row) a vector of (targetStateId, Likelihood) (of type MatrixEntry)
     MatrixType _action_to_target_states;
 
@@ -143,6 +156,9 @@ class ExplorationInformation {
 
     // Assigns for each explored state a reward. Unexplored states will have infinite reward
     std::vector<ValueType> _state_to_reward;
+
+    // Keep the compressed state in memory in case we need to output the generated traces
+    std::vector<storm::generator::CompressedState> _state_to_compressed_state;
 
     IdToStateMap _unexplored_states;
 

--- a/include/samples/traces_exporter.h
+++ b/include/samples/traces_exporter.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Robert Bosch GmbH and its subsidiaries
+ * 
+ * This file is part of smc_storm.
+ * 
+ * smc_storm is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * smc_storm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with smc_storm.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <storm/generator/CompressedState.h>
+#include <storm/generator/VariableInformation.h>
+#include "samples/trace_information.hpp"
+
+namespace smc_storm::samples
+{
+/*!
+ * @brief An helper class to export the generated traces to a CSV file.
+ */
+class TracesExporter
+{
+public:
+    TracesExporter(const std::filesystem::path& path_to_file, const storm::generator::VariableInformation& var_info);
+    ~TracesExporter();
+    // TODO: Add information about the taken action and the current reward
+    void addNextState(const storm::generator::CompressedState& state);
+    /*!
+     * @brief Write the current trace's verification result and start the next trace
+     * @param result 
+     */
+    void addCurrentTraceResult(const TraceInformation& result);
+private:
+    std::ofstream _file;
+    const storm::generator::VariableInformation& _var_info;
+    size_t _trace_counter;
+    size_t _n_variables;
+};
+} // namespace smc_storm::samples

--- a/include/settings/cmd_settings.hpp
+++ b/include/settings/cmd_settings.hpp
@@ -35,6 +35,9 @@ namespace smc_storm::settings {
             parser.add_argument("--stat-method")
                 .default_value(_loaded_settings.stat_method)
                 .help("Statistical method to use.");
+            parser.add_argument("--traces-file")
+                .default_value(_loaded_settings.traces_file)
+                .help("Path to the traces file.");
             parser.add_argument("--confidence")
                 .scan<'g', double>()
                 .default_value(_loaded_settings.confidence)
@@ -46,11 +49,19 @@ namespace smc_storm::settings {
             parser.add_argument("--max-trace-length")
                 .scan<'i', int>()
                 .default_value(_loaded_settings.max_trace_length)
-                .help("Maximum number of iterations (0 -> inf).");
+                .help("Maximum number of steps in a single trace (0 -> inf).");
+            parser.add_argument("--max-n-traces")
+                .scan<'i', size_t>()
+                .default_value(_loaded_settings.max_n_traces)
+                .help("Maximum number of traces to generate (for debugging reasons, overrides stat_method. 0 -> unset).");
             parser.add_argument("--n-threads")
                 .scan<'i', size_t>()
                 .default_value(_loaded_settings.n_threads)
                 .help("Number of threads to use.");
+            parser.add_argument("--batch-size")
+                .scan<'i', size_t>()
+                .default_value(_loaded_settings.batch_size)
+                .help("Batch size for the sampling.");
             parser.add_argument("--show-statistics")
                 .default_value(false)
                 .implicit_value(true)
@@ -66,10 +77,13 @@ namespace smc_storm::settings {
                 _loaded_settings.constants = parser.get<std::string>("--constants");
                 _loaded_settings.property_name = parser.get<std::string>("--property-name");
                 _loaded_settings.stat_method = parser.get<std::string>("--stat-method");
+                _loaded_settings.traces_file = parser.get<std::string>("--traces-file");
                 _loaded_settings.confidence = parser.get<double>("--confidence");
                 _loaded_settings.epsilon = parser.get<double>("--epsilon");
                 _loaded_settings.max_trace_length = parser.get<int>("--max-trace-length");
+                _loaded_settings.max_n_traces = parser.get<size_t>("--max-n-traces");
                 _loaded_settings.n_threads = parser.get<size_t>("--n-threads");
+                _loaded_settings.batch_size = parser.get<size_t>("--batch-size");
                 _loaded_settings.show_statistics = parser.get<bool>("--show-statistics");
                 _parsing_done = true;
             }

--- a/include/settings/smc_settings.hpp
+++ b/include/settings/smc_settings.hpp
@@ -24,10 +24,13 @@ namespace smc_storm::settings
         std::string property_name;
         std::string constants{""};
         std::string stat_method {""};
+        std::string traces_file {""};
         double confidence {0.95};
         double epsilon {0.01};
         int max_trace_length {1000000};
+        size_t max_n_traces {0U};
         size_t n_threads{1U};
+        size_t batch_size{100U};
         bool show_statistics{false};
     };
 } // namespace smc_storm::settings

--- a/src/model_checker/statistical_model_checker.cpp
+++ b/src/model_checker/statistical_model_checker.cpp
@@ -41,8 +41,7 @@
 namespace smc_storm::model_checker
 {
 StatisticalModelChecker::StatisticalModelChecker(const settings::SmcSettings& settings)
-    : _settings(settings)
-{
+: _settings(settings) {
     // Init loggers
     storm::utility::setUp();
     // Check if settings have been already initialized

--- a/src/parser/parsers.cpp
+++ b/src/parser/parsers.cpp
@@ -27,43 +27,43 @@
 
 namespace smc_storm::parser
 {
-    SymbolicModelAndProperty parseModelAndProperty(const std::filesystem::path& path_to_model, const std::string& property_name, const std::string& user_constants)
-    {
-        if (path_to_model.extension() == ".jani") {
-            return parseJaniModelAndProperty(path_to_model, property_name, user_constants);
-        }
-        STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Only JANI models are supported for now.");
+SymbolicModelAndProperty parseModelAndProperty(const std::filesystem::path& path_to_model, const std::string& property_name, const std::string& user_constants)
+{
+    if (path_to_model.extension() == ".jani") {
+        return parseJaniModelAndProperty(path_to_model, property_name, user_constants);
     }
+    STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Only JANI models are supported for now.");
+}
 
-    SymbolicModelAndProperty parseJaniModelAndProperty(const std::filesystem::path& path_to_model, const std::string& property_name, const std::string& user_constants)
-    {
-        // Load the required model and property
-        const auto model_and_formulae = storm::parser::JaniParser<storm::RationalNumber>::parse(path_to_model.string(), true);
-        model_and_formulae.first.checkValid();
-        const auto model_constants_map = model_and_formulae.first.getConstantsSubstitution();
-        // Fill the returned structure
-        SymbolicModelAndProperty model_and_property;
-        model_and_property.model = storm::storage::SymbolicModelDescription(model_and_formulae.first);
-        model_and_property.property.clear();
-        model_and_property.property.reserve(1U);
-        for (auto const& property : model_and_formulae.second) {
-            if (property.getName() == property_name) {
-                // Do not forget to substitute Jani constants in the property, too!
-                model_and_property.property.emplace_back(property.substitute(model_constants_map));
-                break;
-            }
+SymbolicModelAndProperty parseJaniModelAndProperty(const std::filesystem::path& path_to_model, const std::string& property_name, const std::string& user_constants)
+{
+    // Load the required model and property
+    const auto model_and_formulae = storm::parser::JaniParser<storm::RationalNumber>::parse(path_to_model.string(), true);
+    model_and_formulae.first.checkValid();
+    const auto model_constants_map = model_and_formulae.first.getConstantsSubstitution();
+    // Fill the returned structure
+    SymbolicModelAndProperty model_and_property;
+    model_and_property.model = storm::storage::SymbolicModelDescription(model_and_formulae.first);
+    model_and_property.property.clear();
+    model_and_property.property.reserve(1U);
+    for (auto const& property : model_and_formulae.second) {
+        if (property.getName() == property_name) {
+            // Do not forget to substitute Jani constants in the property, too!
+            model_and_property.property.emplace_back(property.substitute(model_constants_map));
+            break;
         }
-        STORM_LOG_THROW(!model_and_property.property.empty(), storm::exceptions::InvalidPropertyException,
-            "Property not found in model.");
-        // Add the user-defined constants
-        const auto user_constants_map = model_and_property.model.parseConstantDefinitions(user_constants);
-        model_and_property.model = model_and_property.model.preprocess(user_constants_map);
-        model_and_property.property.front() = model_and_property.property.front().substitute(user_constants_map);
-        STORM_LOG_THROW(model_and_property.property.front().getUndefinedConstants().empty(), storm::exceptions::InvalidPropertyException, 
-            "The property uses undefined constants!!!");
-        // Expand the model
-        storm::jani::ModelFeatures supported_features = storm::api::getSupportedJaniFeatures(storm::builder::BuilderType::Explicit);
-        storm::api::simplifyJaniModel(model_and_property.model.asJaniModel(), model_and_property.property, supported_features);
-        return model_and_property;
     }
+    STORM_LOG_THROW(!model_and_property.property.empty(), storm::exceptions::InvalidPropertyException,
+        "Property not found in model.");
+    // Add the user-defined constants
+    const auto user_constants_map = model_and_property.model.parseConstantDefinitions(user_constants);
+    model_and_property.model = model_and_property.model.preprocess(user_constants_map);
+    model_and_property.property.front() = model_and_property.property.front().substitute(user_constants_map);
+    STORM_LOG_THROW(model_and_property.property.front().getUndefinedConstants().empty(), storm::exceptions::InvalidPropertyException, 
+        "The property uses undefined constants!!!");
+    // Expand the model
+    storm::jani::ModelFeatures supported_features = storm::api::getSupportedJaniFeatures(storm::builder::BuilderType::Explicit);
+    storm::api::simplifyJaniModel(model_and_property.model.asJaniModel(), model_and_property.property, supported_features);
+    return model_and_property;
+}
 } // namespace smc_storm::helpers

--- a/src/samples/exploration_information.cpp
+++ b/src/samples/exploration_information.cpp
@@ -16,14 +16,22 @@
  */
 
 #include <storm/utility/macros.h>
+#include <storm/exceptions/IllegalFunctionCallException.h>
 
 #include "samples/exploration_information.h"
 
 namespace smc_storm::samples {
 
 template<typename StateType, typename ValueType>
-ExplorationInformation<StateType, ValueType>::ExplorationInformation() {
+ExplorationInformation<StateType, ValueType>::ExplorationInformation(const bool store_expanded_states)
+ : _store_expanded_states(store_expanded_states) {
     // Do nothing
+}
+
+template<typename StateType, typename ValueType>
+storm::generator::CompressedState const& ExplorationInformation<StateType, ValueType>::getCompressedState(StateType const& state) const {
+    STORM_LOG_THROW(_store_expanded_states, storm::exceptions::IllegalFunctionCallException, "Compressed state storage is not enabled.");
+    return _state_to_compressed_state.at(state);
 }
 
 template<typename StateType, typename ValueType>
@@ -46,6 +54,9 @@ template<typename StateType, typename ValueType>
 void ExplorationInformation<StateType, ValueType>::addUnexploredState(StateType const& state_id, storm::generator::CompressedState const& compressed_state) {
     _state_to_row_group_mapping.push_back(_unexplored_marker);
     _unexplored_states[state_id] = compressed_state;
+    if (_store_expanded_states) {
+        _state_to_compressed_state.push_back(compressed_state);
+    }
 }
 
 template<typename StateType, typename ValueType>

--- a/src/samples/trace_result.cpp
+++ b/src/samples/trace_result.cpp
@@ -15,20 +15,24 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include <storm/utility/macros.h>
+#include <storm/exceptions/UnexpectedException.h>
+
+#include "samples/trace_result.hpp"
 
 namespace smc_storm::samples
 {
+const std::string toString(const TraceResult& result) {
+    switch (result) {
+        case TraceResult::VERIFIED:
+            return "Verified";
+        case TraceResult::NOT_VERIFIED:
+            return "Not verified";
+        case TraceResult::NO_INFO:
+            return "No information";
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::UnexpectedException, "Unknown TraceResult");
+    }
+}
 
-/*!
-* @brief The possible outcome of each generated trace.
-*/
-enum class TraceResult {
-    VERIFIED,
-    NOT_VERIFIED,
-    NO_INFO
-};
-
-const std::string toString(const TraceResult& result);
-    
-} // namespace smc_storm::samples
+}  // namespace smc_storm::samples

--- a/src/samples/traces_exporter.cpp
+++ b/src/samples/traces_exporter.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 Robert Bosch GmbH and its subsidiaries
+ * 
+ * This file is part of smc_storm.
+ * 
+ * smc_storm is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * smc_storm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with smc_storm.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <filesystem>
+
+#include <storm/io/file.h>
+#include <storm/utility/macros.h>
+#include <storm/exceptions/NotSupportedException.h>
+
+#include "samples/traces_exporter.h"
+
+namespace smc_storm::samples
+{
+TracesExporter::TracesExporter(const std::filesystem::path& path_to_file, const storm::generator::VariableInformation& var_info)
+: _var_info(var_info),
+  _trace_counter(0) {
+    STORM_LOG_THROW(!path_to_file.empty(), storm::exceptions::NotSupportedException, "The path to the file is empty!");
+    const auto absolute_path = std::filesystem::absolute(path_to_file);
+    STORM_LOG_THROW(std::filesystem::exists(absolute_path.parent_path()), storm::exceptions::NotSupportedException, "The parent directory does not exist!");
+    STORM_LOG_THROW(!std::filesystem::exists(absolute_path), storm::exceptions::NotSupportedException, "The file already exists!");
+    _n_variables = var_info.locationVariables.size() + var_info.booleanVariables.size() + var_info.integerVariables.size();
+    STORM_LOG_THROW(_n_variables > 0U, storm::exceptions::NotSupportedException, "The provided VariableInformation is empty!");
+    storm::utility::openFile(absolute_path.string(), _file);
+    // Write the header
+    _file << "Trace number, , Result, ,";
+    // Locations
+    for (const auto& loc : var_info.locationVariables) {
+        _file << " " << loc.variable.getName() << ",";
+    }
+    _file << " ,";
+    // Booleans
+    for (const auto& bool_var : var_info.booleanVariables) {
+        _file << " " << bool_var.variable.getName() << ",";
+    }
+    // Integers
+    for (const auto& int_var : var_info.integerVariables) {
+        _file << " " << int_var.variable.getName() << ",";
+    }
+    // No real variables, since they can only be transient
+    _file << "\n\n";
+}
+
+TracesExporter::~TracesExporter() {
+    storm::utility::closeFile(_file);
+}
+
+void TracesExporter::addCurrentTraceResult(const TraceInformation& result) {
+    _file << _trace_counter << ", , " << toString(result.outcome) << ", ,";
+    _trace_counter++;
+    // Add one to account for the empty column between locations and remaining variables
+    for (size_t i = 0; i < _n_variables + 1U; i++) {
+        _file << " ,";
+    }
+    _file << "\n\n";
+}
+
+void TracesExporter::addNextState(const storm::generator::CompressedState& state) {
+    _file << _trace_counter << ", , , ,";
+    // Locations
+    for (const auto& loc_info : _var_info.locationVariables) {
+        const uint_fast64_t& loc_value = (loc_info.bitWidth == 0U ? 0U : state.getAsInt(loc_info.bitOffset, loc_info.bitWidth));
+        _file << " " << loc_value << ",";
+    }
+    _file << " ,";
+    // Booleans
+    for (const auto& bool_info : _var_info.booleanVariables) {
+        const std::string bool_value = (state.get(bool_info.bitOffset) ? "true" : "false");
+        _file << " " << bool_value << ",";
+    }
+    // Integers
+    for (const auto& int_info : _var_info.integerVariables) {
+        const uint_fast64_t int_value = state.getAsInt(int_info.bitOffset, int_info.bitWidth);
+        _file << " " << int_value << ",";
+    }
+    _file << "\n";
+}
+} // namespace smc_storm::samples

--- a/test/test_trace_export.cpp
+++ b/test/test_trace_export.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024 Robert Bosch GmbH and its subsidiaries
+ * 
+ * This file is part of smc_storm.
+ * 
+ * smc_storm is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * smc_storm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with smc_storm.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include <storm/exceptions/NotSupportedException.h>
+
+#include "settings/smc_settings.hpp"
+#include "model_checker/statistical_model_checker.hpp"
+
+const std::filesystem::path test_path{"test_files"};
+const std::filesystem::path test_traces_path{"test_traces"};
+
+smc_storm::settings::SmcSettings getSmcSettings(const std::string& traces_file, const std::filesystem::path& jani_file, const std::string& property, const std::string& constants = "") {
+    smc_storm::settings::SmcSettings settings;
+    settings.model = jani_file.string();
+    settings.property_name = property;
+    settings.constants = constants;
+    // Set Chernoff to default method for better stability in tests
+    settings.stat_method = "chernoff";
+    settings.max_n_traces = 10;
+    settings.traces_file = (test_traces_path / traces_file).string();
+    return settings;
+}
+
+template <typename ResultType>
+ResultType getVerificationResult(const smc_storm::settings::SmcSettings& settings) {
+    smc_storm::model_checker::StatisticalModelChecker smc(settings);
+    smc.check();
+    return smc.getResult<ResultType>();
+}
+
+TEST(ExportTracesCommonCaseTest, TestLeaderSync) {
+    const std::filesystem::path jani_file = test_path / "leader_sync.3-2.v1.jani";
+    const auto smc_settings = getSmcSettings("leader_sync.csv", jani_file, "time");
+    const double result = getVerificationResult<double>(smc_settings);
+    EXPECT_TRUE(std::filesystem::exists(smc_settings.traces_file));
+    EXPECT_GT(result, FLT_EPSILON);
+    std::ifstream traces_file(smc_settings.traces_file, std::ios::in);
+
+    std::string line;
+    while (true) {
+        std::getline(traces_file, line);
+        if (traces_file.peek() != EOF) {
+            traces_file.seekg(1, traces_file.cur);
+            if (traces_file.peek() == EOF) {
+                break;
+            }
+            traces_file.seekg(-1, traces_file.cur);
+        }
+    }
+    EXPECT_EQ(line[0], '9');
+    traces_file.close();
+}
+
+TEST(ExportTracesDeathTest, TestLeaderSync) {
+    const std::filesystem::path jani_file = test_path / "leader_sync.3-2.v1.jani";
+    const auto smc_settings = getSmcSettings("leader_sync_death.csv", jani_file, "time");
+    // Make sure the file already exists
+    std::ofstream ofs(smc_settings.traces_file);
+    ofs << "\n"; 
+    ofs.close();
+    // Ensure the code dies in such case
+    EXPECT_DEATH(getVerificationResult<double>(smc_settings), "");
+}
+
+int main(int argc, char** argv) {
+    // Make sure the initial folder status is as expected
+    std::filesystem::remove_all(test_traces_path);
+    std::filesystem::create_directory(test_traces_path);
+    ::testing::InitGoogleTest(&argc, argv);
+    (void)(::testing::GTEST_FLAG(death_test_style) = "threadsafe");
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Now it is possible to output the traces in CSV format. You can use the newly implemented unit test or the example in the readme to get a CSV trace example.

For now this works only with a single thread, though it wouldn't be too hard to generate multiple files in case of multiple threads (though I do not plan to add that feature, since this is mostly for debugging purposes at the moment)