### PR TITLE
Add progress bar and various improvements

### DIFF
--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -95,7 +95,8 @@ jobs:
             - name: Run tests
               run: |
                     cd build
-                    ctest
+                    # Repeat the failing tests up to 3 times, due to statistical possible failures
+                    ctest --repeat until-pass:3
             - name: Copy lib and executables in deploy folder
               run: |
                     # List all existing dependencies of libstorm

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -47,13 +47,6 @@ jobs:
                 # Master is too active to keep up, stable is too old...
                 ref: 83b9191184e26df272bc698c18bfef3cbfc81874
                 path: external_dependencies/storm
-            # Checkout dependency on smc_verifiable_plugins
-            - name: Checkout smc_verifiable_plugins
-              uses: actions/checkout@v4
-              with:
-                repository: convince-project/smc_verifiable_plugins
-                ref: main
-                path: external_dependencies/smc_verifiable_plugins
             # Enable ccache
             - name: ccache
               uses: hendrikmuhs/ccache-action@v1.2
@@ -76,12 +69,6 @@ jobs:
                     cd external_dependencies/storm/build
                     cmake -DSTORM_USE_SPOT_SHIPPED=ON ..
                     make storm-cli
-            - name: Build smc_verifiable_plugins
-              run: |
-                    mkdir external_dependencies/smc_verifiable_plugins/build
-                    cd external_dependencies/smc_verifiable_plugins/build
-                    cmake -DCMAKE_BUILD_TYPE=Release ..
-                    make
             - name: Build smc_storm
               run: |
                     export STORM_BUILD_DIR=$PWD/external_dependencies/storm/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ FetchContent_MakeAvailable(indicators)
 # smc_verifiable_plugins
 FetchContent_Declare(
     smc_verifiable_plugins
-    GIT_REPOSITORY https://github.com/boschresearch/smc_verifiable_plugins.git
-    GIT_TAG improvement/fetch-content-compatible
+    GIT_REPOSITORY https://github.com/convince-project/smc_verifiable_plugins.git
+    GIT_TAG 0.0.1
 )
 FetchContent_MakeAvailable(smc_verifiable_plugins)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 find_package(storm REQUIRED)  # search for Storm library
-find_package(smc_verifiable_plugins REQUIRED)  # TODO: Check if this can be removed, and we can rely on FetchContent
 
 include(FetchContent)
-# Argparse
+# argparse
 FetchContent_Declare(
     argparse
     GIT_REPOSITORY https://github.com/p-ranav/argparse.git
@@ -42,6 +41,13 @@ FetchContent_Declare(
     GIT_TAG v2.3
 )
 FetchContent_MakeAvailable(indicators)
+# smc_verifiable_plugins
+FetchContent_Declare(
+    smc_verifiable_plugins
+    GIT_REPOSITORY https://github.com/boschresearch/smc_verifiable_plugins.git
+    GIT_TAG improvement/fetch-content-compatible
+)
+FetchContent_MakeAvailable(smc_verifiable_plugins)
 
 include_directories(include)
 
@@ -49,15 +55,15 @@ include_directories(include)
 file(GLOB_RECURSE LIB_SRC_FILES ${PROJECT_SOURCE_DIR}/src/*/*.cpp)
 
 add_library(${PROJECT_NAME}_lib SHARED ${LIB_SRC_FILES})
-target_include_directories(${PROJECT_NAME}_lib PUBLIC ${storm_INCLUDE_DIR} ${smc_verifiable_plugins_INCLUDE_DIR})
-target_link_libraries(${PROJECT_NAME}_lib PUBLIC argparse indicators storm storm-parsers)
+target_include_directories(${PROJECT_NAME}_lib PUBLIC ${storm_INCLUDE_DIR})
+target_link_libraries(${PROJECT_NAME}_lib PUBLIC argparse indicators smc_verifiable_plugins storm storm-parsers)
 
 add_executable(${PROJECT_NAME} src/cli.cpp)
 target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_lib)
 
 # Provide some smc_verifiable_plugins implementations
 add_library(uniform_random_smc_plugin SHARED ${PROJECT_SOURCE_DIR}/plugins/src/uniform_random_smc_plugin.cpp)
-target_include_directories(uniform_random_smc_plugin PUBLIC ${smc_verifiable_plugins_INCLUDE_DIR})
+target_link_libraries(uniform_random_smc_plugin PUBLIC smc_verifiable_plugins)
 
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,10 @@ if(BUILD_TESTING)
   target_link_libraries(test_states_generator ${PROJECT_NAME}_lib GTest::gtest GTest::gtest_main)
   gtest_add_tests(TARGET test_states_generator WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
+  add_executable(test_statistical_methods test/unit_tests/test_statistical_methods.cpp)
+  target_link_libraries(test_statistical_methods ${PROJECT_NAME}_lib GTest::gtest GTest::gtest_main)
+  gtest_add_tests(TARGET test_statistical_methods WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
   # System tests
   add_executable(test_jani_models test/system_tests/test_jani_models.cpp)
   target_link_libraries(test_jani_models ${PROJECT_NAME}_lib GTest::gtest GTest::gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 find_package(storm REQUIRED)  # search for Storm library
-find_package(smc_verifiable_plugins REQUIRED)  # TODO: Once released, this can be made optional and use FetchContent
+find_package(smc_verifiable_plugins REQUIRED)  # TODO: Check if this can be removed, and we can rely on FetchContent
 
 include(FetchContent)
 # Argparse

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ FetchContent_Declare(
     GIT_TAG v3.0
 )
 FetchContent_MakeAvailable(argparse)
+# indicators
+FetchContent_Declare(
+    indicators
+    GIT_REPOSITORY https://github.com/p-ranav/indicators.git
+    GIT_TAG v2.3
+)
+FetchContent_MakeAvailable(indicators)
 
 include_directories(include)
 
@@ -43,7 +50,7 @@ file(GLOB_RECURSE LIB_SRC_FILES ${PROJECT_SOURCE_DIR}/src/*/*.cpp)
 
 add_library(${PROJECT_NAME}_lib SHARED ${LIB_SRC_FILES})
 target_include_directories(${PROJECT_NAME}_lib PUBLIC ${storm_INCLUDE_DIR} ${smc_verifiable_plugins_INCLUDE_DIR})
-target_link_libraries(${PROJECT_NAME}_lib PUBLIC argparse storm storm-parsers)
+target_link_libraries(${PROJECT_NAME}_lib PUBLIC argparse indicators storm storm-parsers)
 
 add_executable(${PROJECT_NAME} src/cli.cpp)
 target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_lib)

--- a/README.md
+++ b/README.md
@@ -3,54 +3,19 @@ A Statistical Model Checker implementation building on top of STORM
 
 ## Installation
 
-### Using deployed binaries
+Please refer to the [online documentation](https://convince-project.github.io/smc_storm/installation.html#how-to-install-smc-storm) for instruction on how to install this package.
 
-We provide pre-built binaries that can be used on Ubuntu. They can be found at the [Releases page](https://github.com/convince-project/smc_storm/releases).
+## Usage
 
-To install them on your machine, extract `smc_storm_executable.tar.gz` and follow these steps:
+### List all available parameters
 
-```bash
-cd smc_storm_executable            # This is the extracted archive
-install.sh --install-dependencies  # This flag will install all  packages required by smc_storm and its dependencies
-export PATH=$PATH:$PWD/bin         # This way, smc_storm can be called from anywhere
-smc_storm --help                   # Make sure the binary runs
-```
-
-### Compile from source
-
-#### Get the Official Storm installed
-This package needs Storm to be built on your local machine. To achieve that, follow the [official documentation](https://www.stormchecker.org/documentation/obtain-storm/build.html).
-
-We used the following command to build storm:
-```bash
-export STORM_DIR=<path-to-storm-repo>
-cmake -DSTORM_USE_SPOT_SHIPPED=ON $STORM_DIR && make -j10
-```
-
-We recommend to use the `master` branch, since it provides the latest features as the trigonometric operators.
-
-#### Build this module
-After cloning this repository, execute the following commands:
-```bash
-mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release && make -j4
-# optionally, run the automatic unit tests to make sure everything works as expected
-ctest
-```
-## Run the executable
-To make the smc_storm executable usable from any folder, we suggest to add the following line to your `~/.bashrc` file or run it before start using the tool:
-```bash
-# Make smc_storm executable from anywhere
-export PATH=$PATH:<path-to-smc-storm-repo>/build/bin
-```
-
-## Available parameters
 The list of available parameters with its related description can be obtained using following command:
 ```bash
 smc_storm --help
 ```
 
-## Examples
+### Run some examples
+
 ```bash
 # Example 1
 smc_storm --model <path-to-smc-storm-repo>/test/models/leader_sync.3-2.v1.jani --property-name eventually_elected --batch-size 200
@@ -59,3 +24,7 @@ smc_storm --model <path-to-smc-storm-repo>/test/models/nand.v1.jani --property-n
 # Example 3 (rm added to make sure the csv file doesn't exist at smc_storm execution time)
 rm -f exported_traces.csv && smc_storm --model <path-to-smc-storm-repo>/test/models/leader_sync.3-2.v1.jani --property-name time --traces-file exported_traces.csv --show-statistics --max-n-traces 5
 ```
+
+## Citing this work
+
+If you want to cite this tool, you can refer to the paper [Towards verifying robotic systems using statistical model checking in STORM](https://link.springer.com/chapter/10.1007/978-3-031-75434-0_28).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please refer to the [online documentation](https://convince-project.github.io/sm
 
 ### List all available parameters
 
-The list of available parameters with its related description can be obtained using following command:
+The list of available parameters with its related description can be obtained using the following command:
 ```bash
 smc_storm --help
 ```

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -37,22 +37,6 @@ We used the following command to build STORM:
     export STORM_DIR=<path-to-storm-repo>
     cmake -DSTORM_USE_SPOT_SHIPPED=ON $STORM_DIR && make -j10
 
-Install smc_verifiable_plugins
-______________________________
-
-This is another dependency, providing support for external plugins that can be executed by smc_storm when simulating the model.
-
-The package can be found at `this link <https://github.com/convince-project/smc_verifiable_plugins>_`.
-
-Once cloned, you can use the following:
-
-.. code-block:: bash
-
-    cd <path-to-smc-storm-repo>
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release && make
-
 Install smc_storm
 _________________
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,8 +4,10 @@ Installation Guide
 How to install smc_storm
 ------------------------
 
-Use deployed binaries
-+++++++++++++++++++++
+smc_storm can be obtained in many different ways:
+
+Using deployed binaries
+++++++++++++++++++++++++
 
 We provide pre-built binaries that can be used on Ubuntu. They can be found at the `Releases page <https://github.com/convince-project/smc_storm/releases>`_.
 
@@ -35,6 +37,22 @@ We used the following command to build STORM:
     export STORM_DIR=<path-to-storm-repo>
     cmake -DSTORM_USE_SPOT_SHIPPED=ON $STORM_DIR && make -j10
 
+Install smc_verifiable_plugins
+______________________________
+
+This is another dependency, providing support for external plugins that can be executed by smc_storm when simulating the model.
+
+The package can be found at `this link <https://github.com/convince-project/smc_verifiable_plugins>_`.
+
+Once cloned, you can use the following:
+
+.. code-block:: bash
+
+    cd <path-to-smc-storm-repo>
+    mkdir build
+    cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Release && make
+
 Install smc_storm
 _________________
 
@@ -47,16 +65,39 @@ Once STORM is installed, smc_storm can be built using the following:
     cd build
     cmake .. -DCMAKE_BUILD_TYPE=Release && make -j4
 
-Make smc_storm available from anywhere
-++++++++++++++++++++++++++++++++++++++
+Get a docker container containing smc_storm
++++++++++++++++++++++++++++++++++++++++++++
 
-In order to be able to call smc_storm from anywhere in bash, you can add the smc_storm path to the PATH env variable:
+You can use the `AS2FM <https://github.com/convince-project/AS2FM>_` docker container, that comes with the latest release of smc_storm already installed.
 
 .. code-block:: bash
 
-    export PATH=$PATH:<path-to-smc-storm-repo-bin>
+    docker pull ghcr.io/convince-project/as2fm:latest
+    docker run -it --rm ghcr.io/convince-project/as2fm:latest
 
-The path will depend on the used installation strategy:
+Make smc_storm available from anywhere
+++++++++++++++++++++++++++++++++++++++
+
+To make it possible to call smc_storm from anywhere in your system, we recommend two possible options:
+
+Option 1: Add a symlink in ~/.local/bin
+_______________________________________
+
+.. code-block:: bash
+
+    cd ~/.local/bin
+    ln -s ln -s <path-to-smc-storm-binary-folder>/smc_storm .
+
+Option 2: Append it to the PATH env variable
+____________________________________________
+
+.. code-block:: bash
+
+    export PATH=$PATH:<path-to-smc-storm-binary-folder>
+
+To avoid doing this each time you open a new terminal, the above line can be added to the `~/.bashrc` file.
+
+The `<path-to-smc-storm-binary-folder>` depends on the chosen installation strategy:
 * If you used the pre-built binaries, the path will be `<path-to-workspace>/smc_storm_executable/bin`
 * If you built from source, the path will be `<path-to-workspace>/smc_storm/build/bin`
 

--- a/include/samples/sampling_results.hpp
+++ b/include/samples/sampling_results.hpp
@@ -112,14 +112,6 @@ class SamplingResults {
     void updateSamplingStatus();
 
     /*!
-     * @brief Check if we have reached the minimum n. of iterations
-     * @return Whether we have reached the minimum n. of iterations
-     */
-    inline bool minIterationsReached() const {
-        return _n_verified + _n_not_verified >= _min_iterations;
-    }
-
-    /*!
      * @brief Calculate the variance of the collected samples, distinguishing between P and E properties
      * @return The compute variance
      */
@@ -157,7 +149,6 @@ class SamplingResults {
     // Collection of bound functions to use. Return value is whether more batches are needed.
     // The following iteration bounds work only on P properties
     bool evaluateWaldBound();
-    bool evaluateAgrestiBound();
     bool evaluateWilsonBound();
     bool evaluateWilsonCorrectedBound();
     bool evaluateClopperPearsonBound();

--- a/include/samples/sampling_results.hpp
+++ b/include/samples/sampling_results.hpp
@@ -129,6 +129,15 @@ class SamplingResults {
     }
 
     /*!
+     * @brief A generic progress estimate. It is not supposed to be very accurate.
+     * @param ci_half_width The currently estimated confidence.
+     * @return The estimated progress (between 0 and 100)
+     */
+    inline size_t computeProgress(const double ci_half_width) const {
+        return static_cast<size_t>(std::max(0.0, 400.0 * (0.25 - (ci_half_width - _settings.epsilon))));
+    }
+
+    /*!
      * @brief Calculate the quantile associated to a specific confidence level (assuming normal distribution)
      * @param confidence The confidence value to use
      * @return The quantile value that will be used to evaluate sampling bounds

--- a/include/samples/sampling_results.hpp
+++ b/include/samples/sampling_results.hpp
@@ -23,6 +23,8 @@
 #include <mutex>
 #include <string>
 
+#include <indicators/progress_bar.hpp>
+
 #include "samples/batch_buffer.hpp"
 #include "samples/batch_results.hpp"
 #include "samples/batch_statistics.hpp"
@@ -54,6 +56,8 @@ class SamplingResults {
         }
         return _settings.batch_size;
     }
+
+    void updateProgressBar() const;
 
     BatchResults getBatchResultInstance() const;
 
@@ -192,6 +196,9 @@ class SamplingResults {
     const size_t _min_iterations;
     // Evaluator of choice to define whether we need more samples or not
     std::function<bool()> _bound_function;
+
+    mutable indicators::ProgressBar _progress_bar;
+    size_t _progress;
 };
 
 }  // namespace smc_storm::samples

--- a/include/settings/smc_settings.hpp
+++ b/include/settings/smc_settings.hpp
@@ -39,12 +39,14 @@ struct SmcSettings {
     const bool store_only_not_verified;
     const bool cache_explored_states;
     const bool show_statistics;
+    const bool hide_prog_bar;
 
     SmcSettings(const UserSettings& user_settings)
         : stat_method{user_settings.stat_method}, traces_file{user_settings.traces_file}, confidence{user_settings.confidence},
           epsilon{user_settings.epsilon}, max_trace_length{user_settings.max_trace_length}, max_n_traces{user_settings.max_n_traces},
           n_threads{user_settings.n_threads}, batch_size{user_settings.batch_size}, plugins_loaded{!user_settings.plugin_paths.empty()},
           stop_after_failure{user_settings.stop_after_failure}, store_only_not_verified{user_settings.store_only_not_verified},
-          cache_explored_states{user_settings.cache_explored_states}, show_statistics{user_settings.show_statistics} {}
+          cache_explored_states{user_settings.cache_explored_states}, show_statistics{user_settings.show_statistics},
+          hide_prog_bar(user_settings.hide_prog_bar) {}
 };
 }  // namespace smc_storm::settings

--- a/include/settings/user_settings.hpp
+++ b/include/settings/user_settings.hpp
@@ -42,6 +42,7 @@ struct UserSettings {
     bool store_only_not_verified{false};
     bool cache_explored_states{true};
     bool show_statistics{false};
+    bool hide_prog_bar{false};
 
     bool validModel() const {
         const bool valid_file = !model_file.empty() && std::filesystem::exists(model_file);

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -31,8 +31,8 @@ int main(int argc, char* argv[]) {
     const auto model_and_properties = smc_storm::parser::parseModelAndProperties(user_settings);
     const auto mc_settings = smc_storm::settings::SmcSettings(user_settings);
     // Perform model checking
-    STORM_PRINT("Welcome to SMC Storm\n");
-    STORM_PRINT("Checking model: " << user_settings.model_file << std::endl);
+    std::cout << "Welcome to SMC Storm\n";
+    std::cout << "Checking model: " << user_settings.model_file << std::endl << std::flush;
     // Validate user inputs
     STORM_LOG_THROW(
         smc_storm::model_checker::areModelAndSettingsValid(model_and_properties, mc_settings), storm::exceptions::InvalidSettingsException,

--- a/src/model_checker/statistical_model_checker.cpp
+++ b/src/model_checker/statistical_model_checker.cpp
@@ -46,7 +46,7 @@ StatisticalModelChecker::StatisticalModelChecker(
 StatisticalModelChecker::~StatisticalModelChecker() = default;
 
 void StatisticalModelChecker::printProperty() const {
-    STORM_PRINT("Property " << _property.get().asPrismSyntax() << "\n");
+    std::cout << "Property " << _property.get().asPrismSyntax() << std::endl << std::flush;
 }
 
 void StatisticalModelChecker::check() {
@@ -77,7 +77,7 @@ void StatisticalModelChecker::check() {
             STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Only DTMC and MDP models are supported.");
         }
     }
-    STORM_PRINT("Result: " << *_result << std::endl);
+    std::cout << "Result: " << *_result << std::endl;
 }
 
 template <>

--- a/src/model_checker/statistical_model_checking_engine.cpp
+++ b/src/model_checker/statistical_model_checking_engine.cpp
@@ -251,14 +251,12 @@ samples::TraceInformation StatisticalModelCheckingEngine<ModelType, CacheData>::
     // As long as we didn't find a terminal (accepting or rejecting) state in the search, sample a new successor.
     samples::TraceResult path_result = samples::TraceResult::NO_INFO;
     state_generation.resetModel();
-    // STORM_PRINT("\n----- New trace ----\n");
     while (path_result == samples::TraceResult::NO_INFO) {
         const auto& state_info = state_generation.getStateInfo();
         if (_traces_exporter_ptr) {
             _traces_exporter_ptr->addNextState(state_generation.getCurrentState());
         }
         // Reward calculation pt. 1: Add the state reward
-        // STORM_PRINT("\t(" << state_generation.getStateReward() << ",");
         trace_information.reward += state_generation.getStateReward();
 
         // Do the check before emplacing back to get the correct n. of steps!
@@ -287,14 +285,9 @@ samples::TraceInformation StatisticalModelCheckingEngine<ModelType, CacheData>::
                 const auto available_actions = state_generation.getAvailableActions();
                 const size_t chosen_idx = action_sampler.sampleAction(available_actions);
                 // Reward calculation pt. 2: Add the action reward
-                // STORM_PRINT("\t" << available_actions[chosen_idx].second << ",");
                 trace_information.reward += available_actions[chosen_idx].second;
                 // Reward calculation pt. 3: Add the destination reward
-                // const auto dest_rew = state_generation.runAction(available_actions[chosen_idx].first);
-                // trace_information.reward += dest_rew;
-                // STORM_PRINT("\t" << dest_rew << ")\n");
                 trace_information.reward += state_generation.runAction(available_actions[chosen_idx].first);
-                // STORM_PRINT("\t" << trace_information.reward << "\n");
                 ++trace_information.trace_length;
             }
         }

--- a/src/samples/sampling_results.cpp
+++ b/src/samples/sampling_results.cpp
@@ -17,6 +17,7 @@
 
 #include <boost/math/distributions/beta.hpp>
 #include <boost/math/distributions/normal.hpp>
+#include <sstream>
 
 #include <storm/exceptions/NotImplementedException.h>
 #include <storm/exceptions/OutOfRangeException.h>
@@ -31,12 +32,12 @@ SamplingResults::SamplingResults(const settings::SmcSettings& settings, const st
     // TODO: results_buffer has an hardcoded max. n. of buffered results per thread (6)
     : _settings{settings},
       _results_buffer(settings.n_threads, 6U), _property_type{prop}, _quantile{calculateQuantile(_settings.confidence)},
-      _min_iterations{50U}, _progress_bar{
-                                indicators::option::BarWidth{50},    indicators::option::Start{"["},
-                                indicators::option::Fill{"■"},       indicators::option::Lead{"-"},
-                                indicators::option::Remainder{"-"},  indicators::option::End{"]"},
-                                indicators::option::PostfixText{""}, indicators::option::ShowPercentage{true},
-                            } {
+      _min_iterations{200U}, _progress_bar{
+                                 indicators::option::BarWidth{50},    indicators::option::Start{"["},
+                                 indicators::option::Fill{"■"},       indicators::option::Lead{"-"},
+                                 indicators::option::Remainder{"-"},  indicators::option::End{"]"},
+                                 indicators::option::PostfixText{""}, indicators::option::ShowPercentage{true},
+                             } {
     _keep_sampling = true;
     _n_verified = 0U;
     _n_not_verified = 0U;
@@ -51,9 +52,9 @@ SamplingResults::SamplingResults(const settings::SmcSettings& settings, const st
 }
 
 void SamplingResults::updateProgressBar() const {
-    const size_t total_samples = _n_verified + _n_not_verified + _n_no_info;
-    _progress_bar.set_option(indicators::option::PostfixText(std::string("Computed samples: ") + std::to_string(total_samples)));
-    _progress_bar.set_progress(_progress);
+    _progress_bar.set_option(indicators::option::PostfixText(
+        (std::ostringstream() << " - S: " << _n_verified << " F: " << _n_not_verified << " U: " << _n_no_info).str()));
+    _progress_bar.set_progress(std::min(size_t(100U), _progress));
 }
 
 BatchResults SamplingResults::getBatchResultInstance() const {
@@ -82,8 +83,6 @@ void SamplingResults::initBoundFunction() {
         _bound_function = std::bind(&SamplingResults::evaluateChowRobbinsBound, this);
     } else if ("wald" == stat_method) {
         _bound_function = std::bind(&SamplingResults::evaluateWaldBound, this);
-    } else if ("agresti" == stat_method) {
-        _bound_function = std::bind(&SamplingResults::evaluateAgrestiBound, this);
     } else if ("wilson" == stat_method) {
         _bound_function = std::bind(&SamplingResults::evaluateWilsonBound, this);
     } else if ("wilson_corrected" == stat_method) {
@@ -99,27 +98,29 @@ void SamplingResults::initBoundFunction() {
 }
 
 bool SamplingResults::evaluateChernoffBound() {
+    _progress = static_cast<size_t>(static_cast<double>(_n_verified + _n_not_verified) * 100.0 / _required_samples);
     return (_n_verified + _n_not_verified) < _required_samples;
 }
 
 bool SamplingResults::evaluateWaldBound() {
-    const double successes = static_cast<double>(_n_verified);
-    const double failures = static_cast<double>(_n_not_verified);
-    const double iterations = successes + failures;
-    const double success_proportion = successes / iterations;
-    double ci_half_width = _quantile * sqrt(success_proportion * (1 - success_proportion) / iterations);
-    // Boolean to make sure the certainty bound computed with the Wald bound is inside the desired interval
-    return ci_half_width > _settings.epsilon;
-}
-
-bool SamplingResults::evaluateAgrestiBound() {
-    const double successes = static_cast<double>(_n_verified);
-    const double failures = static_cast<double>(_n_not_verified);
-    const double iterations = successes + failures;
-    const double adjusted_success_proportion = (successes + 0.5 * _quantile) / (iterations + _quantile * _quantile);
-    // Boolean to make sure the certainty bound computed with the Agresti bound is inside the desired interval
-    return _quantile * sqrt(adjusted_success_proportion * (1.0 - adjusted_success_proportion) / (iterations + _quantile * _quantile)) >
-           _settings.epsilon;
+    // This method can be used only after a min. amount of samples has been extracted
+    const size_t n_iterations = _n_verified + _n_not_verified;
+    if (n_iterations < _min_iterations) {
+        _progress = (100u * n_iterations) / _min_iterations;
+        return true;
+    }
+    const double p_succ = static_cast<double>(_n_verified) / static_cast<double>(n_iterations);
+    // Original formulation:
+    // double ci_half_width = _quantile * sqrt(success_proportion * (1 - success_proportion) / iterations);
+    // Manipulate the formula to get the min amount of iterations (given the current successes/failures ratio)
+    const double eps_over_q = _settings.epsilon / _quantile;
+    const size_t req_iterations = static_cast<size_t>(p_succ * (1 - p_succ) / (eps_over_q * eps_over_q));
+    if (req_iterations <= 0u) {
+        _progress = 100u;
+    } else {
+        _progress = (100u * n_iterations) / req_iterations;
+    }
+    return n_iterations < req_iterations;
 }
 
 bool SamplingResults::evaluateWilsonBound() {
@@ -129,6 +130,8 @@ bool SamplingResults::evaluateWilsonBound() {
     const double z = _quantile;
     const double z_sq = z * z;
     const double ci_half_width = (z / (iterations + z_sq)) * sqrt(successes * failures / iterations + z_sq / 4.0);
+    // TODO: Not really a formal progress bar, need to compute it more properly
+    _progress = static_cast<size_t>(200.0 * (ci_half_width - _settings.epsilon));
     // Boolean to make sure the certainty bound computed with the Wilson bound is inside the desired interval
     return ci_half_width > _settings.epsilon;
 }
@@ -137,11 +140,12 @@ bool SamplingResults::evaluateWilsonCorrectedBound() {
     const double successes = static_cast<double>(_n_verified);
     const double failures = static_cast<double>(_n_not_verified);
     const double iterations = successes + failures;
-    const double p = (successes / iterations) - (1.0 / (2.0 * iterations));
     const double z = _quantile;
     const double z_sq = z * z;
     const double ci_half_width =
         (z / (2.0 * (iterations + z_sq))) * sqrt((2.0 * successes - 1.0) * (2.0 * failures + 1.0) * (1.0 / iterations) + z_sq);
+    // TODO: Not really a formal progress bar, need to compute it more properly
+    _progress = static_cast<size_t>(200.0 * (ci_half_width - _settings.epsilon));
     // Boolean to make sure the certainty bound computed with the Wilson bound is inside the desired interval
     return ci_half_width > _settings.epsilon;
 }
@@ -164,19 +168,21 @@ bool SamplingResults::evaluateClopperPearsonBound() {
         upper_bound = boost::math::quantile(upper_dist, 1.0 - alpha_half);
     }
     const double ci_half_width = std::abs(upper_bound - lower_bound) * 0.5;
+    // TODO: Not really a formal progress bar, need to compute it more properly
+    _progress = static_cast<size_t>(200.0 * (ci_half_width - _settings.epsilon));
     return ci_half_width > _settings.epsilon;
 }
 
 bool SamplingResults::evaluateAdaptiveBound() {
     // Based on "A New Adaptive Sampling Method for Scalable Learning" by Chen and Xu (2013)
     const double alpha = (1 - _settings.confidence);
-    const double successes = static_cast<double>(_n_verified);
-    const double iterations = static_cast<double>(_n_verified + _n_not_verified);
-    const double successes_proportion = successes / iterations;
+    const size_t n_iterations = _n_verified + _n_not_verified;
+    const double successes_proportion = static_cast<double>(_n_verified) / static_cast<double>(n_iterations);
     const double corrected_success_prob = abs(successes_proportion - 0.5) - (_settings.epsilon * 2.0 / 3.0);
-    const double min_expected_iterations =
-        (2.0 * log(2.0 / alpha) / (_settings.epsilon * _settings.epsilon)) * (0.25 - corrected_success_prob * corrected_success_prob);
-    return iterations < min_expected_iterations;
+    const size_t min_expected_iterations = static_cast<size_t>(
+        (2.0 * log(2.0 / alpha) / (_settings.epsilon * _settings.epsilon)) * (0.25 - corrected_success_prob * corrected_success_prob));
+    _progress = 100u * n_iterations / min_expected_iterations;
+    return n_iterations < min_expected_iterations;
 }
 
 bool SamplingResults::evaluateArcsineBound() {
@@ -188,22 +194,33 @@ bool SamplingResults::evaluateArcsineBound() {
     const double sqrt_lower_bound = sin(asin(sqrt(adjusted_success_proportion)) - interval_modifier);
     const double sqrt_upper_bound = sin(asin(sqrt(adjusted_success_proportion)) + interval_modifier);
     // Boolean to make sure the certainty bound computed with the Arcsine bound is inside the desired interval
-    return abs(sqrt_lower_bound * sqrt_lower_bound - sqrt_upper_bound * sqrt_upper_bound) > _settings.epsilon * 2.0;
+    const double ci_half_width = std::abs(sqrt_lower_bound * sqrt_lower_bound - sqrt_upper_bound * sqrt_upper_bound) * 0.5;
+    // TODO: Not really a formal progress bar, need to compute it more properly
+    _progress = static_cast<size_t>(200.0 * (ci_half_width - _settings.epsilon));
+    return ci_half_width > _settings.epsilon;
 }
 
 bool SamplingResults::evaluateChowRobbinsBound() {
-    const double variance = calculateVariance();
-    const size_t n_samples = _n_verified + _n_not_verified;
-    if (_property_type == state_properties::PropertyType::R) {
-        STORM_LOG_THROW(n_samples == _reward_stats.dim, storm::exceptions::UnexpectedException, "Mismatch in n. of samples.");
-    }
-    if (n_samples == 0U) {
-        // No sample yet! Keep getting samples!
+    // This method can be used only after a min. amount of samples has been extracted
+    const size_t n_iterations = _n_verified + _n_not_verified;
+    if (n_iterations < _min_iterations) {
+        _progress = (100u * n_iterations) / _min_iterations;
         return true;
     }
+    const double variance = calculateVariance();
+    if (_property_type == state_properties::PropertyType::R) {
+        STORM_LOG_THROW(n_iterations == _reward_stats.dim, storm::exceptions::UnexpectedException, "Mismatch in n. of samples.");
+    }
     // Based on "On the Asymptotic Theory of Fixed-Width Sequential Confidence Intervals for the Mean" paper (1965).
-    const double ci_half_width_squared = variance * _quantile * _quantile / static_cast<double>(n_samples);
-    return (_settings.epsilon * _settings.epsilon) < ci_half_width_squared;
+    // Original formula:
+    // const double ci_half_width_squared = variance * _quantile * _quantile / static_cast<double>(n_samples);
+    const double req_iterations = (variance * _quantile * _quantile) / (_settings.epsilon * _settings.epsilon);
+    if (req_iterations <= 0u) {
+        _progress = 100u;
+    } else {
+        _progress = (100u * n_iterations) / req_iterations;
+    }
+    return n_iterations < req_iterations;
 }
 
 void SamplingResults::addBatchResults(const BatchResults& res, const size_t thread_id) {
@@ -297,8 +314,10 @@ void SamplingResults::updateSamplingStatus() {
             _keep_sampling = false;
         } else if (_settings.stop_after_failure && _n_not_verified > 0U) {
             _keep_sampling = false;
-        } else if (!minIterationsReached()) {
-            _keep_sampling = true;
+            // } else if ((_n_verified + _n_not_verified) < _min_iterations) {
+            //     _keep_sampling = true;
+            //     _progress = static_cast<size_t>(100.0 * static_cast<double>(_n_verified + _n_not_verified) /
+            //     static_cast<double>(_min_iterations));
         } else if (n_samples > _min_iterations && _n_no_info > n_samples * 0.5) {
             // Check if we never reached a terminal states
             STORM_LOG_THROW(

--- a/src/samples/sampling_results.cpp
+++ b/src/samples/sampling_results.cpp
@@ -129,6 +129,7 @@ bool SamplingResults::evaluateWaldBound() {
 }
 
 bool SamplingResults::evaluateWilsonBound() {
+    // Source: https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval
     const double successes = static_cast<double>(_n_verified);
     const double failures = static_cast<double>(_n_not_verified);
     const double iterations = successes + failures;

--- a/src/samples/sampling_results.cpp
+++ b/src/samples/sampling_results.cpp
@@ -48,13 +48,18 @@ SamplingResults::SamplingResults(const settings::SmcSettings& settings, const st
     _max_trace_length = 0U;
     _progress = 0u;
     initBoundFunction();
-    updateProgressBar();
+    if (!_settings.hide_prog_bar) {
+        std::cout << "Property evaluation in progress. S: Success, F: Failures, U: Unknown" << std::endl << std::flush;
+        updateProgressBar();
+    }
 }
 
 void SamplingResults::updateProgressBar() const {
-    _progress_bar.set_option(indicators::option::PostfixText(
-        (std::ostringstream() << " - S: " << _n_verified << " F: " << _n_not_verified << " U: " << _n_no_info).str()));
-    _progress_bar.set_progress(std::min(size_t(100U), _progress));
+    if (!_settings.hide_prog_bar) {
+        _progress_bar.set_option(indicators::option::PostfixText(
+            (std::ostringstream() << " (S: " << _n_verified << " F: " << _n_not_verified << " U: " << _n_no_info << ")").str()));
+        _progress_bar.set_progress(std::min(size_t(100U), _progress));
+    }
 }
 
 BatchResults SamplingResults::getBatchResultInstance() const {

--- a/src/samples/sampling_results.cpp
+++ b/src/samples/sampling_results.cpp
@@ -130,8 +130,8 @@ bool SamplingResults::evaluateWilsonBound() {
     const double z = _quantile;
     const double z_sq = z * z;
     const double ci_half_width = (z / (iterations + z_sq)) * sqrt(successes * failures / iterations + z_sq / 4.0);
-    // TODO: Not really a formal progress bar, need to compute it more properly
-    _progress = static_cast<size_t>(200.0 * (ci_half_width - _settings.epsilon));
+    // TODO: Not really a proper progress bar formulation, need to compute it more properly
+    _progress = static_cast<size_t>(std::max(0.0, 400.0 * (0.25 - (ci_half_width - _settings.epsilon))));
     // Boolean to make sure the certainty bound computed with the Wilson bound is inside the desired interval
     return ci_half_width > _settings.epsilon;
 }
@@ -144,8 +144,8 @@ bool SamplingResults::evaluateWilsonCorrectedBound() {
     const double z_sq = z * z;
     const double ci_half_width =
         (z / (2.0 * (iterations + z_sq))) * sqrt((2.0 * successes - 1.0) * (2.0 * failures + 1.0) * (1.0 / iterations) + z_sq);
-    // TODO: Not really a formal progress bar, need to compute it more properly
-    _progress = static_cast<size_t>(200.0 * (ci_half_width - _settings.epsilon));
+    // TODO: Not really a proper progress bar formulation, need to compute it more properly
+    _progress = static_cast<size_t>(std::max(0.0, 400.0 * (0.25 - (ci_half_width - _settings.epsilon))));
     // Boolean to make sure the certainty bound computed with the Wilson bound is inside the desired interval
     return ci_half_width > _settings.epsilon;
 }
@@ -168,8 +168,8 @@ bool SamplingResults::evaluateClopperPearsonBound() {
         upper_bound = boost::math::quantile(upper_dist, 1.0 - alpha_half);
     }
     const double ci_half_width = std::abs(upper_bound - lower_bound) * 0.5;
-    // TODO: Not really a formal progress bar, need to compute it more properly
-    _progress = static_cast<size_t>(200.0 * (ci_half_width - _settings.epsilon));
+    // TODO: Not really a proper progress bar formulation, need to compute it more properly
+    _progress = static_cast<size_t>(std::max(0.0, 400.0 * (0.25 - (ci_half_width - _settings.epsilon))));
     return ci_half_width > _settings.epsilon;
 }
 
@@ -195,8 +195,8 @@ bool SamplingResults::evaluateArcsineBound() {
     const double sqrt_upper_bound = sin(asin(sqrt(adjusted_success_proportion)) + interval_modifier);
     // Boolean to make sure the certainty bound computed with the Arcsine bound is inside the desired interval
     const double ci_half_width = std::abs(sqrt_lower_bound * sqrt_lower_bound - sqrt_upper_bound * sqrt_upper_bound) * 0.5;
-    // TODO: Not really a formal progress bar, need to compute it more properly
-    _progress = static_cast<size_t>(200.0 * (ci_half_width - _settings.epsilon));
+    // TODO: Not really a proper progress bar formulation, need to compute it more properly
+    _progress = static_cast<size_t>(std::max(0.0, 400.0 * (0.25 - (ci_half_width - _settings.epsilon))));
     return ci_half_width > _settings.epsilon;
 }
 

--- a/src/settings/cmd_settings.cpp
+++ b/src/settings/cmd_settings.cpp
@@ -59,6 +59,7 @@ CmdSettings::CmdSettings() : _parser("smc_storm", VERSION) {
         .implicit_value(true)
         .help("Disable storage of the explored states.");
     _parser.add_argument("--show-statistics").default_value(false).implicit_value(true).help("Show statistics after checking.");
+    _parser.add_argument("--hide-progress-bar").default_value(false).implicit_value(true).help("Hide the verification progress bar.");
 }
 void CmdSettings::parse(int argc, char* argv[]) {
     try {
@@ -83,6 +84,7 @@ void CmdSettings::parse(int argc, char* argv[]) {
         _loaded_settings.batch_size = _parser.get<size_t>("--batch-size");
         _loaded_settings.cache_explored_states = !_parser.get<bool>("--disable-explored-states-caching");
         _loaded_settings.show_statistics = _parser.get<bool>("--show-statistics");
+        _loaded_settings.hide_prog_bar = _parser.get<bool>("--hide-progress-bar");
         _parsing_done = true;
     } catch (const std::exception& err) {
         std::cerr << err.what() << std::endl;

--- a/test/unit_tests/test_statistical_methods.cpp
+++ b/test/unit_tests/test_statistical_methods.cpp
@@ -107,11 +107,11 @@ TEST(SamplingResultsTest, WilsonCorrectedBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
     const std::string stat_method = "wilson_corrected";
     const size_t gen_batches_1 = runTest(p_type, stat_method, 1.0);
-    ASSERT_GT(gen_batches_1, 100u);
+    ASSERT_GT(gen_batches_1, 400u);
     const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
-    ASSERT_GT(gen_batches_2, 100u);
+    ASSERT_GT(gen_batches_2, 400u);
     const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
-    ASSERT_GT(gen_batches_3, 600u);
+    ASSERT_GT(gen_batches_3, 5000u);
 }
 
 TEST(SamplingResultsTest, ClopperPearsonBoundProgress) {
@@ -133,7 +133,7 @@ TEST(SamplingResultsTest, AdaptiveBoundProgress) {
     const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
     ASSERT_GT(gen_batches_2, 400u);
     const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
-    ASSERT_GT(gen_batches_3, 600u);
+    ASSERT_GT(gen_batches_3, 5000u);
 }
 
 TEST(SamplingResultsTest, ArcsineBoundProgress) {

--- a/test/unit_tests/test_statistical_methods.cpp
+++ b/test/unit_tests/test_statistical_methods.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Robert Bosch GmbH and its subsidiaries
+ *
+ * This file is part of smc_storm.
+ *
+ * smc_storm is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * smc_storm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with smc_storm.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <storm/settings/SettingsManager.h>
+
+#include "samples/sampling_results.hpp"
+#include "settings/smc_settings.hpp"
+#include "settings/user_settings.hpp"
+#include "state_properties/property_type.hpp"
+
+smc_storm::samples::SamplingResults getSamplingResult(
+    const std::string& stat_method, const smc_storm::state_properties::PropertyType p_type) {
+    smc_storm::settings::UserSettings settings;
+    settings.stat_method = stat_method;
+    settings.n_threads = 1u;
+    return smc_storm::samples::SamplingResults(smc_storm::settings::SmcSettings(settings), p_type);
+}
+
+smc_storm::samples::BatchResults getSamplesBatch(
+    const smc_storm::state_properties::PropertyType p_type, const size_t n_successes, const size_t n_failures,
+    const size_t n_not_terminated) {
+    const size_t batch_size = n_successes + n_failures + n_not_terminated;
+    if (batch_size <= 0u) {
+        throw std::invalid_argument("Batch size must be greater than 0.");
+    }
+    smc_storm::samples::BatchResults single_batch(batch_size, p_type);
+    single_batch.count = batch_size;
+    single_batch.n_verified = n_successes;
+    single_batch.n_not_verified = n_failures;
+    single_batch.n_no_info = n_not_terminated;
+    return single_batch;
+}
+
+TEST(SamplingResultsTest, ChernoffBoundProgress) {
+    const auto p_type = smc_storm::state_properties::PropertyType::P;
+    auto samples_holder = getSamplingResult("chernoff", p_type);
+    // Simulate some verified and not verified samples
+    for (size_t i = 0u; i < 19; i++) {
+        auto batch = getSamplesBatch(p_type, 500u, 500u, 10u);
+        samples_holder.addBatchResults(batch, 0u);
+        ASSERT_EQ(samples_holder.newBatchNeeded(0u), i < 18u);
+    }
+    // (You may need to expose or mock internal state for more detailed tests)
+    ASSERT_NEAR(samples_holder.getProbabilityVerifiedProperty(), 0.5, 0.001);
+}
+
+// TEST(SamplingResultsTest, WaldBoundProgress) {
+//     settings.stat_method = "wald";
+//     SamplingResults waldResults(settings, PropertyType::P);
+//     bool moreNeeded = waldResults.evaluateWaldBound();
+//     ASSERT_TRUE(moreNeeded);
+// }
+
+// Add similar tests for Wilson, WilsonCorrected, ClopperPearson, Adaptive, Arcsine, ChowRobbins
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    // Initialize the default STORM settings (required for comparator)
+    storm::settings::initializeAll("smc_storm", "test_batch_buffer");
+    return RUN_ALL_TESTS();
+}

--- a/test/unit_tests/test_statistical_methods.cpp
+++ b/test/unit_tests/test_statistical_methods.cpp
@@ -24,12 +24,12 @@
 #include "settings/user_settings.hpp"
 #include "state_properties/property_type.hpp"
 
-smc_storm::samples::SamplingResults getSamplingResult(
-    const std::string& stat_method, const smc_storm::state_properties::PropertyType p_type) {
+smc_storm::settings::SmcSettings getRequiredSettings(const std::string& stat_method) {
     smc_storm::settings::UserSettings settings;
     settings.stat_method = stat_method;
     settings.n_threads = 1u;
-    return smc_storm::samples::SamplingResults(smc_storm::settings::SmcSettings(settings), p_type);
+    settings.hide_prog_bar = true;
+    return smc_storm::settings::SmcSettings(settings);
 }
 
 smc_storm::samples::BatchResults getSamplesBatch(
@@ -49,9 +49,10 @@ smc_storm::samples::BatchResults getSamplesBatch(
 
 TEST(SamplingResultsTest, ChernoffBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
-    auto samples_holder = getSamplingResult("chernoff", p_type);
+    auto settings = getRequiredSettings("chernoff");
+    smc_storm::samples::SamplingResults samples_holder(settings, p_type);
     // Simulate some verified and not verified samples
-    for (size_t i = 0u; i < 19; i++) {
+    for (size_t i = 0u; i < 20u; i++) {
         auto batch = getSamplesBatch(p_type, 500u, 500u, 10u);
         samples_holder.addBatchResults(batch, 0u);
         ASSERT_EQ(samples_holder.newBatchNeeded(0u), i < 18u);

--- a/test/unit_tests/test_statistical_methods.cpp
+++ b/test/unit_tests/test_statistical_methods.cpp
@@ -47,14 +47,16 @@ smc_storm::samples::BatchResults getSamplesBatch(
     return single_batch;
 }
 
-void runTest(const smc_storm::state_properties::PropertyType p_type, const std::string& stat_method, const double success_prob) {
+size_t runTest(const smc_storm::state_properties::PropertyType p_type, const std::string& stat_method, const double success_prob) {
     auto settings = getRequiredSettings(stat_method);
     smc_storm::samples::SamplingResults samples_holder(settings, p_type);
     bool always_fail = success_prob < FLT_EPSILON;
     size_t n_succ = 0u;
     size_t n_fail = 0u;
+    size_t n_non_terminating = 0u;
     size_t inverse_prob = always_fail ? std::numeric_limits<size_t>::max() : static_cast<size_t>(std::round(1.0 / success_prob));
     size_t n_batches = 0;
+    size_t total_non_terminating = 0u;
     while (samples_holder.newBatchNeeded(0u)) {
         if (always_fail || n_batches % inverse_prob != 0u) {
             n_succ = 0u;
@@ -63,84 +65,97 @@ void runTest(const smc_storm::state_properties::PropertyType p_type, const std::
             n_succ = 1u;
             n_fail = 0u;
         }
-        samples_holder.addBatchResults(getSamplesBatch(p_type, n_succ, n_fail, 0u), 0u);
+        n_non_terminating = (n_batches % 20 == 0) ? 1u : 0u;
+        samples_holder.addBatchResults(getSamplesBatch(p_type, n_succ, n_fail, n_non_terminating), 0u);
         n_batches++;
-    }
-    EXPECT_GT(n_batches, 100u);
-    if (!(always_fail || inverse_prob == 1U)) {
-        // In this case, we expect more samples
-        EXPECT_GT(n_batches, 600u);
+        total_non_terminating += n_non_terminating;
     }
     EXPECT_NEAR(samples_holder.getProbabilityVerifiedProperty(), success_prob, 0.001);
+    return n_batches;
 }
 
 TEST(SamplingResultsTest, ChernoffBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
-    auto settings = getRequiredSettings("chernoff");
-    smc_storm::samples::SamplingResults samples_holder(settings, p_type);
-    // Simulate some verified and not verified samples
-    for (size_t i = 0u; i < 20u; i++) {
-        auto batch = getSamplesBatch(p_type, 500u, 500u, 10u);
-        samples_holder.addBatchResults(batch, 0u);
-        ASSERT_EQ(samples_holder.newBatchNeeded(0u), i < 18u);
-    }
-    ASSERT_NEAR(samples_holder.getProbabilityVerifiedProperty(), 0.5, 0.001);
+    const std::string stat_method = "chernoff";
+    const size_t gen_batches = runTest(p_type, stat_method, 0.5);
+    ASSERT_GT(gen_batches, 10000u);
 }
 
 TEST(SamplingResultsTest, WaldBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
     const std::string stat_method = "wald";
-    runTest(p_type, stat_method, 1.0);
-    runTest(p_type, stat_method, 0.0);
-    runTest(p_type, stat_method, 0.25);
+    const size_t gen_batches_1 = runTest(p_type, stat_method, 1.0);
+    ASSERT_GT(gen_batches_1, 100u);
+    const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
+    ASSERT_GT(gen_batches_2, 100u);
+    const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
+    ASSERT_GT(gen_batches_3, 600u);
 }
 
 TEST(SamplingResultsTest, WilsonBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
     const std::string stat_method = "wilson";
-    runTest(p_type, stat_method, 1.0);
-    runTest(p_type, stat_method, 0.0);
-    runTest(p_type, stat_method, 0.25);
+    const size_t gen_batches_1 = runTest(p_type, stat_method, 1.0);
+    ASSERT_GT(gen_batches_1, 100u);
+    const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
+    ASSERT_GT(gen_batches_2, 100u);
+    const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
+    ASSERT_GT(gen_batches_3, 600u);
 }
 
 TEST(SamplingResultsTest, WilsonCorrectedBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
     const std::string stat_method = "wilson_corrected";
-    runTest(p_type, stat_method, 1.0);
-    runTest(p_type, stat_method, 0.0);
-    runTest(p_type, stat_method, 0.25);
+    const size_t gen_batches_1 = runTest(p_type, stat_method, 1.0);
+    ASSERT_GT(gen_batches_1, 100u);
+    const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
+    ASSERT_GT(gen_batches_2, 100u);
+    const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
+    ASSERT_GT(gen_batches_3, 600u);
 }
 
 TEST(SamplingResultsTest, ClopperPearsonBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
     const std::string stat_method = "clopper_pearson";
-    runTest(p_type, stat_method, 1.0);
-    runTest(p_type, stat_method, 0.0);
-    runTest(p_type, stat_method, 0.25);
+    const size_t gen_batches_1 = runTest(p_type, stat_method, 1.0);
+    ASSERT_GT(gen_batches_1, 100u);
+    const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
+    ASSERT_GT(gen_batches_2, 100u);
+    const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
+    ASSERT_GT(gen_batches_3, 600u);
 }
 
 TEST(SamplingResultsTest, AdaptiveBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
     const std::string stat_method = "adaptive";
-    runTest(p_type, stat_method, 1.0);
-    runTest(p_type, stat_method, 0.0);
-    runTest(p_type, stat_method, 0.25);
+    const size_t gen_batches_1 = runTest(p_type, stat_method, 1.0);
+    ASSERT_GT(gen_batches_1, 400u);
+    const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
+    ASSERT_GT(gen_batches_2, 400u);
+    const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
+    ASSERT_GT(gen_batches_3, 600u);
 }
 
 TEST(SamplingResultsTest, ArcsineBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
     const std::string stat_method = "arcsine";
-    runTest(p_type, stat_method, 1.0);
-    runTest(p_type, stat_method, 0.0);
-    runTest(p_type, stat_method, 0.25);
+    const size_t gen_batches_1 = runTest(p_type, stat_method, 1.0);
+    ASSERT_GT(gen_batches_1, 100u);
+    const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
+    ASSERT_GT(gen_batches_2, 100u);
+    const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
+    ASSERT_GT(gen_batches_3, 600u);
 }
 
 TEST(SamplingResultsTest, ChowRobbinsBoundProgress) {
     const auto p_type = smc_storm::state_properties::PropertyType::P;
     const std::string stat_method = "chow_robbins";
-    runTest(p_type, stat_method, 1.0);
-    runTest(p_type, stat_method, 0.0);
-    runTest(p_type, stat_method, 0.25);
+    const size_t gen_batches_1 = runTest(p_type, stat_method, 1.0);
+    ASSERT_GT(gen_batches_1, 100u);
+    const size_t gen_batches_2 = runTest(p_type, stat_method, 0.0);
+    ASSERT_GT(gen_batches_2, 100u);
+    const size_t gen_batches_3 = runTest(p_type, stat_method, 0.25);
+    ASSERT_GT(gen_batches_3, 600u);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
I finally added a small progress bar in SMC Storm, and while I was at that, I added unit tests for all the statistical methods and fixed a bug in the Wilson method with continuity correction.

Finally, I updated the documentation and improved the CMake file to get the smc_verifiable_plugins package on its own, instead of requiring developers to download it on their own.

This can be merged after this other PR: https://github.com/convince-project/smc_verifiable_plugins/pull/2