### PR TITLE
Traces on multiple files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 # set the project name and version
-project(smc_storm VERSION 0.1.5)
+project(smc_storm VERSION 0.1.6)
 
 # Use RelWithDebInfo by default
 if(NOT CMAKE_BUILD_TYPE)

--- a/include/model_checker/statistical_model_checking_engine.hpp
+++ b/include/model_checker/statistical_model_checking_engine.hpp
@@ -123,7 +123,13 @@ class StatisticalModelCheckingEngine : public storm::modelchecker::AbstractModel
         const storm::modelchecker::CheckTask<storm::logic::Formula, ValueType>& check_task,
         std::default_random_engine& random_generator) const;
 
-    void instantiateTraceGenerator(const StateGeneratorType& state_generator);
+    std::unique_ptr<TraceExportType> instantiateTraceGenerator(const StateGeneratorType& state_generator) {
+        if (traceStorageEnabled()) {
+            const int thread_id = gettid();
+            return std::make_unique<TraceExportType>(_traces_folder, state_generator.getVariableInformation(), thread_id);
+        }
+        return nullptr;
+    }
 
     bool verifyModelValid() const;
 
@@ -151,13 +157,13 @@ class StatisticalModelCheckingEngine : public storm::modelchecker::AbstractModel
      * @return A pair with the Information attached to the reached state and the accumulated reward
      */
     samples::TraceInformation samplePathFromInitialState(
-        StateGeneratorType& state_generation, const state_generation::ActionScheduler<ValueType>& action_sampler) const;
+        StateGeneratorType& state_generation, const state_generation::ActionScheduler<ValueType>& action_sampler,
+        const std::unique_ptr<TraceExportType>& trace_exporter_ptr) const;
 
     // The model to check.
     std::reference_wrapper<const storm::storage::SymbolicModelDescription> _model;
     std::reference_wrapper<const settings::SmcSettings> _settings;
     std::reference_wrapper<const std::vector<SmcPluginInstance>> _loaded_plugins;
-    std::unique_ptr<TraceExportType> _traces_exporter_ptr;
     std::string _traces_folder = "";
 };
 }  // namespace model_checker

--- a/include/model_checker/statistical_model_checking_engine.hpp
+++ b/include/model_checker/statistical_model_checking_engine.hpp
@@ -158,6 +158,7 @@ class StatisticalModelCheckingEngine : public storm::modelchecker::AbstractModel
     std::reference_wrapper<const settings::SmcSettings> _settings;
     std::reference_wrapper<const std::vector<SmcPluginInstance>> _loaded_plugins;
     std::unique_ptr<TraceExportType> _traces_exporter_ptr;
+    std::string _traces_folder = "";
 };
 }  // namespace model_checker
 }  // namespace smc_storm

--- a/include/settings/smc_settings.hpp
+++ b/include/settings/smc_settings.hpp
@@ -34,6 +34,7 @@ struct SmcSettings {
     const size_t max_n_traces;
     const size_t n_threads;
     const size_t batch_size;
+    const bool traces_add_date;
     const bool plugins_loaded;
     const bool stop_after_failure;
     const bool store_only_not_verified;
@@ -42,9 +43,10 @@ struct SmcSettings {
     const bool hide_prog_bar;
 
     SmcSettings(const UserSettings& user_settings)
-        : stat_method{user_settings.stat_method}, traces_folder{user_settings.traces_folder}, confidence{user_settings.confidence},
-          epsilon{user_settings.epsilon}, max_trace_length{user_settings.max_trace_length}, max_n_traces{user_settings.max_n_traces},
-          n_threads{user_settings.n_threads}, batch_size{user_settings.batch_size}, plugins_loaded{!user_settings.plugin_paths.empty()},
+        : stat_method{user_settings.stat_method}, traces_folder{user_settings.traces_folder},
+          confidence{user_settings.confidence}, epsilon{user_settings.epsilon}, max_trace_length{user_settings.max_trace_length},
+          max_n_traces{user_settings.max_n_traces}, n_threads{user_settings.n_threads}, batch_size{user_settings.batch_size},
+          traces_add_date{user_settings.traces_add_date}, plugins_loaded{!user_settings.plugin_paths.empty()},
           stop_after_failure{user_settings.stop_after_failure}, store_only_not_verified{user_settings.store_only_not_verified},
           cache_explored_states{user_settings.cache_explored_states}, show_statistics{user_settings.show_statistics},
           hide_prog_bar(user_settings.hide_prog_bar) {}

--- a/include/settings/smc_settings.hpp
+++ b/include/settings/smc_settings.hpp
@@ -27,7 +27,7 @@ namespace smc_storm::settings {
  */
 struct SmcSettings {
     const std::string stat_method;
-    const std::string traces_file;
+    const std::string traces_folder;
     const double confidence;
     const double epsilon;
     const int max_trace_length;
@@ -42,7 +42,7 @@ struct SmcSettings {
     const bool hide_prog_bar;
 
     SmcSettings(const UserSettings& user_settings)
-        : stat_method{user_settings.stat_method}, traces_file{user_settings.traces_file}, confidence{user_settings.confidence},
+        : stat_method{user_settings.stat_method}, traces_folder{user_settings.traces_folder}, confidence{user_settings.confidence},
           epsilon{user_settings.epsilon}, max_trace_length{user_settings.max_trace_length}, max_n_traces{user_settings.max_n_traces},
           n_threads{user_settings.n_threads}, batch_size{user_settings.batch_size}, plugins_loaded{!user_settings.plugin_paths.empty()},
           stop_after_failure{user_settings.stop_after_failure}, store_only_not_verified{user_settings.store_only_not_verified},

--- a/include/settings/user_settings.hpp
+++ b/include/settings/user_settings.hpp
@@ -30,7 +30,7 @@ struct UserSettings {
     std::string custom_property = "";
     std::string constants{""};
     std::string stat_method{""};
-    std::string traces_file{""};
+    std::string traces_folder{""};
     std::string plugin_paths{""};
     double confidence{0.95};
     double epsilon{0.01};

--- a/include/settings/user_settings.hpp
+++ b/include/settings/user_settings.hpp
@@ -38,6 +38,7 @@ struct UserSettings {
     size_t max_n_traces{0U};
     size_t n_threads{1U};
     size_t batch_size{100U};
+    bool traces_add_date{false};
     bool stop_after_failure{false};
     bool store_only_not_verified{false};
     bool cache_explored_states{true};

--- a/src/model_checker/statistical_model_checking_engine.cpp
+++ b/src/model_checker/statistical_model_checking_engine.cpp
@@ -46,6 +46,7 @@
 #include <storm/utility/prism.h>
 #include <storm/utility/random.h>
 
+#include <storm/exceptions/FileIoException.h>
 #include <storm/exceptions/InvalidModelException.h>
 #include <storm/exceptions/InvalidOperationException.h>
 #include <storm/exceptions/InvalidPropertyException.h>
@@ -103,10 +104,16 @@ StatisticalModelCheckingEngine<ModelType, CacheData>::StatisticalModelCheckingEn
     STORM_LOG_THROW(verifySettingsValid(), storm::exceptions::InvalidSettingsException, "Invalid settings provided: cannot evaluate!");
     if (traceStorageEnabled()) {
         std::stringstream folder_name_stream;
-        const std::time_t now = std::time(nullptr);
-        folder_name_stream << _settings.get().traces_folder << "_" << std::put_time(std::localtime(&now), "%Y-%m-%d-%H-%M-%S");
+        folder_name_stream << _settings.get().traces_folder;
+        if (_settings.get().traces_add_date) {
+            const std::time_t now = std::time(nullptr);
+            folder_name_stream << std::put_time(std::localtime(&now), "_%Y-%m-%d-%H-%M-%S");
+        }
         _traces_folder = folder_name_stream.str();
         STORM_PRINT("Writing traces to folder " + _traces_folder);
+        STORM_LOG_THROW(
+            !std::filesystem::exists(_traces_folder), storm::exceptions::FileIoException,
+            "The folder " + _traces_folder + " already exists.");
         std::filesystem::create_directory(_traces_folder);
     }
 }

--- a/src/samples/traces_exporter.cpp
+++ b/src/samples/traces_exporter.cpp
@@ -54,6 +54,7 @@ void TracesExporter::addCurrentTraceResult(const TraceInformation& result) {
         for (size_t i = 0; i < _n_variables + 1U; i++) {
             _current_file << ";";
         }
+        _current_file << "\n";
         _trace_counter++;
         storm::io::closeFile(_current_file);
         std::rename(_tmp_filename_path.c_str(), (_traces_folder / generateNewFilename(result.outcome)).c_str());

--- a/src/samples/traces_exporter.cpp
+++ b/src/samples/traces_exporter.cpp
@@ -26,162 +26,163 @@
 namespace smc_storm::samples {
 
 // TracesExporter methods
-TracesExporter::TracesExporter(const std::filesystem::path& path_to_file) : _trace_counter(0) {
-    STORM_LOG_THROW(!path_to_file.empty(), storm::exceptions::NotSupportedException, "The path to the file is empty!");
-    const auto absolute_path = std::filesystem::absolute(path_to_file);
+TracesExporter::TracesExporter(const std::filesystem::path& path_to_folder, const int thread_id)
+    : _trace_counter(0), _traces_folder(std::filesystem::absolute(path_to_folder)), _thread_id(thread_id),
+      _tmp_filename_path(_traces_folder / ("_tmp_trace_thread_" + std::to_string(_thread_id) + ".csv")) {
+    STORM_LOG_THROW(!path_to_folder.empty(), storm::exceptions::NotSupportedException, "The path to the the traces folder is empty!");
     STORM_LOG_THROW(
-        std::filesystem::exists(absolute_path.parent_path()), storm::exceptions::NotSupportedException,
-        "The parent directory does not exist!");
-    STORM_LOG_THROW(!std::filesystem::exists(absolute_path), storm::exceptions::NotSupportedException, "The file already exists!");
-    storm::io::openFile(absolute_path.string(), _file);
+        std::filesystem::exists(_traces_folder), storm::exceptions::NotSupportedException,
+        "The folder " + _traces_folder.string() + " does not exist!");
 }
 
 TracesExporter::~TracesExporter() {
-    storm::io::closeFile(_file);
+    if (_current_file.is_open()) {
+        storm::io::closeFile(_current_file);
+    }
+}
+
+void TracesExporter::createNewTraceFile() {
+    STORM_LOG_THROW(
+        !_current_file.is_open(), storm::exceptions::FileIoException, "Trying to open a new file before closing the previous one");
+    storm::io::openFile(_tmp_filename_path, _current_file, false, true);
 }
 
 void TracesExporter::addCurrentTraceResult(const TraceInformation& result) {
     if (!_export_only_failures || result.outcome == smc_storm::samples::TraceResult::NOT_VERIFIED) {
-        // In case we are not exporting only failures, this vector will have no effect
-        writeCachedStates();
-        _file << _trace_counter << ";;" << toString(result.outcome) << ";;";
-        _trace_counter++;
+        _current_file << _trace_counter << ";;" << toString(result.outcome) << ";;";
         // Add one to account for the empty column between locations and remaining variables
         for (size_t i = 0; i < _n_variables + 1U; i++) {
-            _file << ";";
+            _current_file << ";";
         }
-        _file << "\n\n";
+        _trace_counter++;
+        storm::io::closeFile(_current_file);
+        std::rename(_tmp_filename_path.c_str(), generateNewFilename(result.outcome).c_str());
+    } else {
+        // Discard the trace
+        storm::io::closeFile(_current_file);
+        std::remove(_tmp_filename_path.c_str());
     }
-    clearTraces();
+}
+
+const std::string TracesExporter::generateNewFilename(const smc_storm::samples::TraceResult& res) {
+    std::string suffix;
+    if (smc_storm::samples::TraceResult::VERIFIED == res) {
+        suffix = "_verified";
+    } else if (smc_storm::samples::TraceResult::NOT_VERIFIED == res) {
+        suffix = "_not_verified";
+    } else {
+        suffix = "_unknown";
+    }
+    std::stringstream stream;
+    stream << "trace_" << _thread_id << "_" << std::setw(6) << std::setfill('0') << _trace_counter << suffix;
+    return stream.str();
 }
 
 // CompressedStateTraceExporter methods
 CompressedStateTraceExporter::CompressedStateTraceExporter(
-    const std::filesystem::path& path_to_file, const storm::generator::VariableInformation& var_info)
-    : TracesExporter(path_to_file), _var_info{var_info} {
+    const std::filesystem::path& path_to_file, const storm::generator::VariableInformation& var_info, const int thread_id)
+    : TracesExporter(path_to_file, thread_id), _var_info{var_info} {
     _n_variables = var_info.locationVariables.size() + var_info.booleanVariables.size() + var_info.integerVariables.size();
     STORM_LOG_THROW(_n_variables > 0U, storm::exceptions::NotSupportedException, "The provided VariableInformation is empty!");
+}
+
+void CompressedStateTraceExporter::startNewTrace() {
+    createNewTraceFile();
+
     // Write the header
-    _file << "Trace number;;Result;;";
+    _current_file << "Trace number;;Result;;";
     // Locations
-    for (const auto& loc : var_info.locationVariables) {
-        _file << loc.variable.getName() << ";";
+    for (const auto& loc : _var_info.locationVariables) {
+        _current_file << loc.variable.getName() << ";";
     }
-    _file << ";";
+    _current_file << ";";
     // Booleans
-    for (const auto& bool_var : var_info.booleanVariables) {
-        _file << bool_var.variable.getName() << ";";
+    for (const auto& bool_var : _var_info.booleanVariables) {
+        _current_file << bool_var.variable.getName() << ";";
     }
     // Integers
-    for (const auto& int_var : var_info.integerVariables) {
-        _file << int_var.variable.getName() << ";";
+    for (const auto& int_var : _var_info.integerVariables) {
+        _current_file << int_var.variable.getName() << ";";
     }
     // No real variables, since they can only be transient
-    _file << "\n\n";
-    _current_trace_states.clear();
+    _current_file << "\n\n";
 }
 
 void CompressedStateTraceExporter::addNextState(const storm::generator::CompressedState& state) {
-    if (_export_only_failures) {
-        _current_trace_states.emplace_back(state);
-    } else {
-        writeNextState(state);
-    }
-}
-
-void CompressedStateTraceExporter::writeCachedStates() {
-    for (const auto& state : _current_trace_states) {
-        writeNextState(state);
-    }
-}
-
-void CompressedStateTraceExporter::writeNextState(const storm::generator::CompressedState& state) {
-    _file << _trace_counter << ";;;;";
+    _current_file << _trace_counter << ";;;;";
     // Locations
     for (const auto& loc_info : _var_info.locationVariables) {
         const uint_fast64_t& loc_value = (loc_info.bitWidth == 0U ? 0U : state.getAsInt(loc_info.bitOffset, loc_info.bitWidth));
-        _file << loc_value << ";";
+        _current_file << loc_value << ";";
     }
-    _file << ";";
+    _current_file << ";";
     // Booleans
     for (const auto& bool_info : _var_info.booleanVariables) {
         const std::string bool_value = (state.get(bool_info.bitOffset) ? "true" : "false");
-        _file << bool_value << ";";
+        _current_file << bool_value << ";";
     }
     // Integers
     for (const auto& int_info : _var_info.integerVariables) {
         const int_fast64_t int_value = state.getAsInt(int_info.bitOffset, int_info.bitWidth) + int_info.lowerBound;
-        _file << int_value << ";";
+        _current_file << int_value << ";";
     }
-    _file << "\n";
+    _current_file << "\n";
 }
 
 // UncompressedStateTraceExporter
 UncompressedStateTraceExporter::UncompressedStateTraceExporter(
-    const std::filesystem::path& path_to_file, const state_properties::StateVariableInformation<double>& var_info)
-    : TracesExporter(path_to_file), _var_info{var_info} {
+    const std::filesystem::path& path_to_file, const state_properties::StateVariableInformation<double>& var_info, const int thread_id)
+    : TracesExporter(path_to_file, thread_id), _var_info{var_info} {
     _n_variables = var_info.locationVariables().size() + var_info.booleanVariables().size() + var_info.integerVariables().size() +
                    var_info.realVariables().size();
     STORM_LOG_THROW(_n_variables > 0U, storm::exceptions::NotSupportedException, "The provided VariableInformation is empty!");
+}
+
+void UncompressedStateTraceExporter::startNewTrace() {
+    createNewTraceFile();
     // Write the header
-    _file << "Trace number;;Result;;";
+    _current_file << "Trace number;;Result;;";
     // Locations
-    for (const auto& loc : var_info.locationVariables()) {
-        _file << loc.variable.getName() << ";";
+    for (const auto& loc : _var_info.locationVariables()) {
+        _current_file << loc.variable.getName() << ";";
     }
-    _file << ";";
+    _current_file << ";";
     // Booleans
-    for (const auto& bool_var : var_info.booleanVariables()) {
-        _file << bool_var.variable.getName() << ";";
+    for (const auto& bool_var : _var_info.booleanVariables()) {
+        _current_file << bool_var.variable.getName() << ";";
     }
     // Integers
-    for (const auto& int_var : var_info.integerVariables()) {
-        _file << int_var.variable.getName() << ";";
+    for (const auto& int_var : _var_info.integerVariables()) {
+        _current_file << int_var.variable.getName() << ";";
     }
     // Reals
-    for (const auto& real_var : var_info.realVariables()) {
-        _file << real_var.variable.getName() << ";";
+    for (const auto& real_var : _var_info.realVariables()) {
+        _current_file << real_var.variable.getName() << ";";
     }
-    // No real variables, since they can only be transient
-    _file << "\n\n";
-    _current_trace_states.clear();
+    _current_file << "\n\n";
 }
 
 void UncompressedStateTraceExporter::addNextState(const state_properties::StateVariableData<double>& state) {
-    if (_export_only_failures) {
-        _current_trace_states.emplace_back(state);
-    } else {
-        writeNextState(state);
-    }
-}
-
-void UncompressedStateTraceExporter::writeCachedStates() {
-    for (const auto& state : _current_trace_states) {
-        writeNextState(state);
-    }
-}
-
-void UncompressedStateTraceExporter::writeNextState(const state_properties::StateVariableData<double>& state) {
-    _file << _trace_counter << ";;;;";
+    _current_file << _trace_counter << ";;;;";
     // Locations
     for (const auto& loc_value : state.getLocationData()) {
-        _file << loc_value << ";";
+        _current_file << loc_value << ";";
     }
-    _file << ";";
+    _current_file << ";";
     // Booleans
     for (const auto& bool_value : state.getBoolData()) {
         const std::string bool_str = bool_value ? "true" : "false";
-        _file << bool_str << ";";
+        _current_file << bool_str << ";";
     }
     // Integers
     for (const auto& int_value : state.getIntData()) {
-        _file << int_value << ";";
+        _current_file << int_value << ";";
     }
     // Reals
     for (const auto& real_value : state.getRealData()) {
-        _file << real_value << ";";
+        _current_file << real_value << ";";
     }
-    _file << "\n";
+    _current_file << "\n";
 }
 
 }  // namespace smc_storm::samples

--- a/src/samples/traces_exporter.cpp
+++ b/src/samples/traces_exporter.cpp
@@ -56,7 +56,7 @@ void TracesExporter::addCurrentTraceResult(const TraceInformation& result) {
         }
         _trace_counter++;
         storm::io::closeFile(_current_file);
-        std::rename(_tmp_filename_path.c_str(), generateNewFilename(result.outcome).c_str());
+        std::rename(_tmp_filename_path.c_str(), (_traces_folder / generateNewFilename(result.outcome)).c_str());
     } else {
         // Discard the trace
         storm::io::closeFile(_current_file);
@@ -80,8 +80,8 @@ const std::string TracesExporter::generateNewFilename(const smc_storm::samples::
 
 // CompressedStateTraceExporter methods
 CompressedStateTraceExporter::CompressedStateTraceExporter(
-    const std::filesystem::path& path_to_file, const storm::generator::VariableInformation& var_info, const int thread_id)
-    : TracesExporter(path_to_file, thread_id), _var_info{var_info} {
+    const std::filesystem::path& path_to_folder, const storm::generator::VariableInformation& var_info, const int thread_id)
+    : TracesExporter(path_to_folder, thread_id), _var_info{var_info} {
     _n_variables = var_info.locationVariables.size() + var_info.booleanVariables.size() + var_info.integerVariables.size();
     STORM_LOG_THROW(_n_variables > 0U, storm::exceptions::NotSupportedException, "The provided VariableInformation is empty!");
 }
@@ -131,8 +131,8 @@ void CompressedStateTraceExporter::addNextState(const storm::generator::Compress
 
 // UncompressedStateTraceExporter
 UncompressedStateTraceExporter::UncompressedStateTraceExporter(
-    const std::filesystem::path& path_to_file, const state_properties::StateVariableInformation<double>& var_info, const int thread_id)
-    : TracesExporter(path_to_file, thread_id), _var_info{var_info} {
+    const std::filesystem::path& path_to_folder, const state_properties::StateVariableInformation<double>& var_info, const int thread_id)
+    : TracesExporter(path_to_folder, thread_id), _var_info{var_info} {
     _n_variables = var_info.locationVariables().size() + var_info.booleanVariables().size() + var_info.integerVariables().size() +
                    var_info.realVariables().size();
     STORM_LOG_THROW(_n_variables > 0U, storm::exceptions::NotSupportedException, "The provided VariableInformation is empty!");

--- a/src/settings/cmd_settings.cpp
+++ b/src/settings/cmd_settings.cpp
@@ -33,6 +33,10 @@ CmdSettings::CmdSettings() : _parser("smc_storm", VERSION) {
     _parser.add_argument("--custom-property").default_value(_loaded_settings.custom_property).help("Custom property to check.");
     _parser.add_argument("--stat-method").default_value(_loaded_settings.stat_method).help("Statistical method to use.");
     _parser.add_argument("--traces-folder").default_value(_loaded_settings.traces_folder).help("Path to the traces folder.");
+    _parser.add_argument("--append-date")
+        .default_value(false)
+        .implicit_value(true)
+        .help("Whether to add the current date to the traces folder.");
     _parser.add_argument("--plugin-paths").default_value(_loaded_settings.plugin_paths).help("Where to load the SMC plugins from.");
     _parser.add_argument("--confidence").scan<'g', double>().default_value(_loaded_settings.confidence).help("Confidence level.");
     _parser.add_argument("--epsilon").scan<'g', double>().default_value(_loaded_settings.epsilon).help("Maximum absolute error.");
@@ -76,6 +80,7 @@ void CmdSettings::parse(int argc, char* argv[]) {
         _loaded_settings.custom_property = _parser.get<std::string>("--custom-property");
         _loaded_settings.stat_method = _parser.get<std::string>("--stat-method");
         _loaded_settings.traces_folder = _parser.get<std::string>("--traces-folder");
+        _loaded_settings.traces_add_date = _parser.get<bool>("--add-date");
         _loaded_settings.plugin_paths = _parser.get<std::string>("--plugin-paths");
         _loaded_settings.confidence = _parser.get<double>("--confidence");
         _loaded_settings.epsilon = _parser.get<double>("--epsilon");

--- a/src/settings/cmd_settings.cpp
+++ b/src/settings/cmd_settings.cpp
@@ -32,7 +32,7 @@ CmdSettings::CmdSettings() : _parser("smc_storm", VERSION) {
         .help("Names of the properties to check, separated by commas. If empty, all properties will be checked.");
     _parser.add_argument("--custom-property").default_value(_loaded_settings.custom_property).help("Custom property to check.");
     _parser.add_argument("--stat-method").default_value(_loaded_settings.stat_method).help("Statistical method to use.");
-    _parser.add_argument("--traces-file").default_value(_loaded_settings.traces_file).help("Path to the traces file.");
+    _parser.add_argument("--traces-folder").default_value(_loaded_settings.traces_folder).help("Path to the traces folder.");
     _parser.add_argument("--plugin-paths").default_value(_loaded_settings.plugin_paths).help("Where to load the SMC plugins from.");
     _parser.add_argument("--confidence").scan<'g', double>().default_value(_loaded_settings.confidence).help("Confidence level.");
     _parser.add_argument("--epsilon").scan<'g', double>().default_value(_loaded_settings.epsilon).help("Maximum absolute error.");
@@ -75,7 +75,7 @@ void CmdSettings::parse(int argc, char* argv[]) {
         _loaded_settings.properties_names = _parser.get<std::string>("--properties-names");
         _loaded_settings.custom_property = _parser.get<std::string>("--custom-property");
         _loaded_settings.stat_method = _parser.get<std::string>("--stat-method");
-        _loaded_settings.traces_file = _parser.get<std::string>("--traces-file");
+        _loaded_settings.traces_folder = _parser.get<std::string>("--traces-folder");
         _loaded_settings.plugin_paths = _parser.get<std::string>("--plugin-paths");
         _loaded_settings.confidence = _parser.get<double>("--confidence");
         _loaded_settings.epsilon = _parser.get<double>("--epsilon");


### PR DESCRIPTION
With this feature, we introduce support for multiple threads generating traces by having each trace in its own file.
The flag has been renamed from traces-file to traces-folder, and we add a new flag to append the current date to the folder name.