### PR TITLE
Feature more information in output

### DIFF
--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
     build:
         runs-on: ubuntu-latest
-        container: ubuntu:22.04
+        container: ubuntu:24.04
         steps:
             - name: Update apt
               run: |

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -89,18 +89,18 @@ jobs:
                     # List all existing dependencies of libstorm
                     echo "libstorm dependencies:"
                     ldd external_dependencies/storm/build/lib/libstorm.so
-                    CARL_LIB=$(ldd external_dependencies/storm/build/lib/libstorm.so | grep -E -o 'libcarl\.so(\.[0-9]*)+' | head -1)
-                    SPOT_LIB=$(ldd external_dependencies/storm/build/lib/libstorm.so | grep -E -o 'libspot\.so(\.[0-9]*)+' | head -1)
-                    BDDX_LIB=$(ldd external_dependencies/storm/build/lib/libstorm.so | grep -E -o 'libbddx\.so(\.[0-9]*)+' | head -1)
+                    CARL_LIB=$(ldd external_dependencies/storm/build/lib/libstorm.so | grep -E -o '[/a-zA-Z0-9\_\-]+libcarl\.so(\.[0-9]*)+' | head -1)
+                    SPOT_LIB=$(ldd external_dependencies/storm/build/lib/libstorm.so | grep -E -o '[/a-zA-Z0-9\_\-]+libspot\.so(\.[0-9]*)+' | head -1)
+                    BDDX_LIB=$(ldd external_dependencies/storm/build/lib/libstorm.so | grep -E -o '[/a-zA-Z0-9\_\-]+libbddx\.so(\.[0-9]*)+' | head -1)
                     mkdir deployment
                     cd deployment
                     # Copy the dependencies
                     mkdir 3rd_party
                     cp ../external_dependencies/storm/build/lib/libstorm.so 3rd_party
                     cp ../external_dependencies/storm/build/lib/libstorm-parsers.so 3rd_party
-                    cp ../external_dependencies/storm/build/resources/3rdparty/carl/$CARL_LIB 3rd_party
-                    cp ../external_dependencies/storm/build/resources/3rdparty/spot/lib/$SPOT_LIB 3rd_party
-                    cp ../external_dependencies/storm/build/resources/3rdparty/spot/lib/$BDDX_LIB 3rd_party
+                    cp $CARL_LIB 3rd_party
+                    cp $SPOT_LIB 3rd_party
+                    cp $BDDX_LIB 3rd_party
                     # Copy the smc_storm lib
                     mkdir lib
                     cp ../build/lib/libsmc_storm_lib.so lib

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -39,13 +39,13 @@ jobs:
             # Checkout this repository
             - name: Checkout repository
               uses: actions/checkout@v4
-            # Checkout storm dependency (to switch to the official one once support for sin/cos is integrated)
+            # Checkout storm dependency
             - name: Checkout STORM
               uses: actions/checkout@v4
               with:
                 repository: moves-rwth/storm
                 # Master is too active to keep up, stable is too old...
-                ref: 83b9191184e26df272bc698c18bfef3cbfc81874
+                ref: 498ea0cc8c393c04ed2b36510a4eb4e1805d484e
                 path: external_dependencies/storm
             # Enable ccache
             - name: ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.25)
 
 # set the project name and version
 project(smc_storm VERSION 0.1.7)
@@ -56,7 +56,7 @@ file(GLOB_RECURSE LIB_SRC_FILES ${PROJECT_SOURCE_DIR}/src/*/*.cpp)
 
 add_library(${PROJECT_NAME}_lib SHARED ${LIB_SRC_FILES})
 add_definitions(-DSMC_STORM_VERSION="${CMAKE_PROJECT_VERSION}")
-target_include_directories(${PROJECT_NAME}_lib SYSTEM BEFORE ${storm_INCLUDE_DIR})
+target_include_directories(${PROJECT_NAME}_lib SYSTEM PUBLIC ${storm_INCLUDE_DIR})
 target_link_libraries(${PROJECT_NAME}_lib PUBLIC argparse indicators smc_verifiable_plugins storm storm-parsers)
 
 add_executable(${PROJECT_NAME} src/cli.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ file(GLOB_RECURSE LIB_SRC_FILES ${PROJECT_SOURCE_DIR}/src/*/*.cpp)
 
 add_library(${PROJECT_NAME}_lib SHARED ${LIB_SRC_FILES})
 add_definitions(-DSMC_STORM_VERSION="${CMAKE_PROJECT_VERSION}")
-target_include_directories(${PROJECT_NAME}_lib PUBLIC ${storm_INCLUDE_DIR})
+target_include_directories(${PROJECT_NAME}_lib SYSTEM BEFORE ${storm_INCLUDE_DIR})
 target_link_libraries(${PROJECT_NAME}_lib PUBLIC argparse indicators smc_verifiable_plugins storm storm-parsers)
 
 add_executable(${PROJECT_NAME} src/cli.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 # set the project name and version
-project(smc_storm VERSION 0.1.6)
+project(smc_storm VERSION 0.1.7)
 
 # Use RelWithDebInfo by default
 if(NOT CMAKE_BUILD_TYPE)

--- a/include/model_checker/statistical_model_checking_engine.hpp
+++ b/include/model_checker/statistical_model_checking_engine.hpp
@@ -17,13 +17,15 @@
 
 #pragma once
 
+#include <functional>
+#include <map>
+
 #include <storm/modelchecker/AbstractModelChecker.h>
 
 // This is the generic description able to contain both Jani and Prism models
-#include <storm/storage/SymbolicModelDescription.h>
-
 #include <storm/generator/CompressedState.h>
 #include <storm/generator/VariableInformation.h>
+#include <storm/storage/SymbolicModelDescription.h>
 
 #include <storm/utility/ConstantsComparator.h>
 

--- a/include/samples/batch_statistics.hpp
+++ b/include/samples/batch_statistics.hpp
@@ -27,6 +27,8 @@ namespace smc_storm::samples {
 struct BatchStatistics {
     double mean;
     double variance;
+    double min_val;
+    double max_val;
     size_t dim;
 
     /*!

--- a/include/samples/sampling_results.hpp
+++ b/include/samples/sampling_results.hpp
@@ -176,9 +176,7 @@ class SamplingResults {
     size_t _n_verified;
     size_t _n_not_verified;
     size_t _n_no_info;
-    // Variables to keep track of rewards (WIP, will need to be extended for different bound methods)
-    double _min_reward;
-    double _max_reward;
+    // Variables to keep track of rewards
     BatchStatistics _reward_stats;
 
     // Variables to keep track of the trace lengths

--- a/include/samples/sampling_results.hpp
+++ b/include/samples/sampling_results.hpp
@@ -159,13 +159,21 @@ class SamplingResults {
     // The following iteration bounds work only on P properties
     bool evaluateWaldBound();
     bool evaluateWilsonBound();
+    double computeWilsonCorrectedEpsilon() const;
     bool evaluateWilsonCorrectedBound();
     bool evaluateClopperPearsonBound();
     bool evaluateAdaptiveBound();
     bool evaluateArcsineBound();
-    // The following iteration bounds work R properties, too
+    // The following iteration bounds work for R properties, too
     bool evaluateChernoffBound();
+    double computeChowRobbinsEpsilon() const;
     bool evaluateChowRobbinsBound();
+
+    /*!
+     * @brief Estimate the Half CI interval
+     * @return The estimated value and the method used to compute it.
+     */
+    std::string computeEpsilonEstimate() const;
 
     mutable std::mutex _mtx;
     // The kind of property we need to evaluate

--- a/include/settings/smc_settings.hpp
+++ b/include/settings/smc_settings.hpp
@@ -43,12 +43,11 @@ struct SmcSettings {
     const bool hide_prog_bar;
 
     SmcSettings(const UserSettings& user_settings)
-        : stat_method{user_settings.stat_method}, traces_folder{user_settings.traces_folder},
-          confidence{user_settings.confidence}, epsilon{user_settings.epsilon}, max_trace_length{user_settings.max_trace_length},
-          max_n_traces{user_settings.max_n_traces}, n_threads{user_settings.n_threads}, batch_size{user_settings.batch_size},
-          traces_add_date{user_settings.traces_add_date}, plugins_loaded{!user_settings.plugin_paths.empty()},
-          stop_after_failure{user_settings.stop_after_failure}, store_only_not_verified{user_settings.store_only_not_verified},
-          cache_explored_states{user_settings.cache_explored_states}, show_statistics{user_settings.show_statistics},
-          hide_prog_bar(user_settings.hide_prog_bar) {}
+        : stat_method{user_settings.stat_method}, traces_folder{user_settings.traces_folder}, confidence{user_settings.confidence},
+          epsilon{user_settings.epsilon}, max_trace_length{user_settings.max_trace_length}, max_n_traces{user_settings.max_n_traces},
+          n_threads{user_settings.n_threads}, batch_size{user_settings.batch_size}, traces_add_date{user_settings.traces_add_date},
+          plugins_loaded{!user_settings.plugin_paths.empty()}, stop_after_failure{user_settings.stop_after_failure},
+          store_only_not_verified{user_settings.store_only_not_verified}, cache_explored_states{user_settings.cache_explored_states},
+          show_statistics{user_settings.show_statistics}, hide_prog_bar(user_settings.hide_prog_bar) {}
 };
 }  // namespace smc_storm::settings

--- a/include/state_properties/state_variable_information.hpp
+++ b/include/state_properties/state_variable_information.hpp
@@ -142,7 +142,7 @@ class StateVariableInformation {
   public:
     StateVariableInformation() = default;
     StateVariableInformation(
-        const storm::jani::Model& model, const std::vector<std::reference_wrapper<storm::jani::Automaton const>>& parallel_automata,
+        const storm::jani::Model& model, const std::vector<std::reference_wrapper<const storm::jani::Automaton>>& parallel_automata,
         bool out_of_bounds_state);
 
     inline bool checkVariableBounds() const {

--- a/src/model_checker/statistical_model_checking_engine.cpp
+++ b/src/model_checker/statistical_model_checking_engine.cpp
@@ -148,7 +148,7 @@ bool StatisticalModelCheckingEngine<ModelType, CacheData>::verifySettingsValid()
     }
     STORM_LOG_WARN_COND(
         _settings.get().max_n_traces == 0U && !_settings.get().stop_after_failure,
-        "The amount of generated traces is limited. This might affect reliability of the results.");
+        "The amount of generated traces is limited. The result's error (epsilon) might be higher than requested.");
     return is_settings_valid;
 }
 

--- a/src/samples/sampling_results.cpp
+++ b/src/samples/sampling_results.cpp
@@ -30,14 +30,13 @@
 namespace smc_storm::samples {
 SamplingResults::SamplingResults(const settings::SmcSettings& settings, const state_properties::PropertyType& prop)
     // TODO: results_buffer has an hardcoded max. n. of buffered results per thread (6)
-    : _settings{settings},
-      _results_buffer(settings.n_threads, 6U), _property_type{prop}, _quantile{calculateQuantile(_settings.confidence)},
-      _min_iterations{200U}, _progress_bar{
-                                 indicators::option::BarWidth{50},    indicators::option::Start{"["},
-                                 indicators::option::Fill{"■"},       indicators::option::Lead{"-"},
-                                 indicators::option::Remainder{"-"},  indicators::option::End{"]"},
-                                 indicators::option::PostfixText{""}, indicators::option::ShowPercentage{true},
-                             } {
+    : _settings{settings}, _results_buffer(settings.n_threads, 6U), _property_type{prop},
+      _quantile{calculateQuantile(_settings.confidence)}, _min_iterations{200U},
+      _progress_bar{
+          indicators::option::BarWidth{50},    indicators::option::Start{"["},           indicators::option::Fill{"■"},
+          indicators::option::Lead{"-"},       indicators::option::Remainder{"-"},       indicators::option::End{"]"},
+          indicators::option::PostfixText{""}, indicators::option::ShowPercentage{true},
+      } {
     _keep_sampling = true;
     _n_verified = 0U;
     _n_not_verified = 0U;

--- a/src/state_generation/jani_smc_states_expansion.cpp
+++ b/src/state_generation/jani_smc_states_expansion.cpp
@@ -34,12 +34,10 @@ template <typename ValueType>
 JaniSmcStatesExpansion<ValueType>::JaniSmcStatesExpansion(
     const storm::jani::Model& jani_model, const std::optional<std::string>& reward_name,
     const std::vector<model_checker::SmcPluginInstance>& external_plugins, std::default_random_engine& random_generator)
-    : _random_generator{random_generator},
-      _jani_model(jani_model), _external_plugins_desc{external_plugins}, _reward{
-                                                                             storm::builder::RewardModelInformation(
-                                                                                 "", false, false, false),
-                                                                             storm::expressions::Expression(),
-                                                                             storm::utility::zero<ValueType>()} {
+    : _random_generator{random_generator}, _jani_model(jani_model), _external_plugins_desc{external_plugins},
+      _reward{
+          storm::builder::RewardModelInformation("", false, false, false), storm::expressions::Expression(),
+          storm::utility::zero<ValueType>()} {
     loadReward(reward_name);
     checkSupportedFeatures();
     loadPlugins();

--- a/src/state_properties/state_variable_information.cpp
+++ b/src/state_properties/state_variable_information.cpp
@@ -29,7 +29,7 @@ namespace smc_storm::state_properties {
 
 template <typename RealValueType>
 StateVariableInformation<RealValueType>::StateVariableInformation(
-    const storm::jani::Model& model, const std::vector<std::reference_wrapper<storm::jani::Automaton const>>& parallel_automata,
+    const storm::jani::Model& model, const std::vector<std::reference_wrapper<const storm::jani::Automaton>>& parallel_automata,
     bool out_of_bounds_state)
     : _check_bounds{out_of_bounds_state} {
     processVariableSet(model.getGlobalVariables(), true);


### PR DESCRIPTION
This PR introduces the computation of the Epsilon (or CI half width) when printing the complete statistics.
Since not all methods are explicitly computing that value, I opted for using the Wilson Corrected Score and the Chow Robbins bounds for P and R properties, respectively.
An exemplary output is the following:
```
============= SMC Results =============
        N. of times target reached:     3986
        N. of times no termination:     0
        Tot. n. of tries (samples):     4200
        Estimated success prob.:        0.949047619
        Confidence score: 0.95
        Estimated Epsilon: 0.00677898 (Corrected Wilson Method)

        Min trace length:       180
        Max trace length:       529
=========================================
Result: 0.949047619
```